### PR TITLE
Passing 'LibraryView' to child items

### DIFF
--- a/src/LibraryView.tsx
+++ b/src/LibraryView.tsx
@@ -68,6 +68,7 @@ export class LibraryView {
 
         let htmlElement = document.getElementById(this.htmlElementId);
         ReactDOM.render(<LibraryContainer
+            libraryView={this}
             loadedTypesJson={this.loadedTypesJson}
             layoutSpecsJson={this.layoutSpecsJson} />, htmlElement);
     }

--- a/src/components/ClusterView.tsx
+++ b/src/components/ClusterView.tsx
@@ -18,10 +18,16 @@
 */
 
 import * as React from "react";
+import { LibraryView } from "../LibraryView";
 import { LibraryItem } from "./LibraryItem";
 import { ItemData } from "../LibraryUtilities";
 
-export interface ClusterViewProps { iconPath: string, borderColor: string, childItems: ItemData[] }
+export interface ClusterViewProps {
+    libraryView: LibraryView,
+    iconPath: string,
+    borderColor: string,
+    childItems: ItemData[]
+}
 
 export class ClusterView extends React.Component<ClusterViewProps, undefined> {
 
@@ -47,7 +53,7 @@ export class ClusterView extends React.Component<ClusterViewProps, undefined> {
 
         let index = 0;
         return this.props.childItems.map((item: ItemData) => {
-            return (<LibraryItem key={index++} data={item} />);
+            return (<LibraryItem key={index++} libraryView={this.props.libraryView} data={item} />);
         });
     }
 

--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -1,12 +1,14 @@
 /// <reference path="../../node_modules/@types/node/index.d.ts" />
 
 import * as React from "react";
+import { LibraryView } from "../LibraryView";
 import { LibraryItem } from "./LibraryItem";
 import { buildLibraryItemsFromLayoutSpecs, ItemData } from "../LibraryUtilities";
 
 declare var boundContainer: any; // Object set from C# side.
 
 export interface LibraryContainerProps {
+    libraryView: LibraryView,
     loadedTypesJson: any,
     layoutSpecsJson: any
 }
@@ -29,7 +31,7 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
         try {
             let index = 0;
             const childItems = this.generatedLibraryItems;
-            const listItems = childItems.map((item: ItemData) => (<LibraryItem key={index++} data={item} />));
+            const listItems = childItems.map((item: ItemData) => (<LibraryItem key={index++} libraryView={this.props.libraryView} data={item} />));
 
             return (<div>{listItems}</div>);
         }

--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -18,9 +18,10 @@
 
 import * as React from "react";
 import { ClusterView } from "./ClusterView";
+import { LibraryView } from "../LibraryView";
 import { ItemData } from "../LibraryUtilities";
 
-export interface LibraryItemProps { data: ItemData }
+export interface LibraryItemProps { libraryView: LibraryView, data: ItemData }
 export interface LibraryItemState { expanded: boolean }
 
 class GroupedItems {
@@ -133,7 +134,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
                     // types of items except ones of type creation/action/query.
                     // 
                     regularItems.map((item: ItemData) => {
-                        return (<LibraryItem key={index++} data={item} />);
+                        return (<LibraryItem key={index++} libraryView={this.props.libraryView} data={item} />);
                     })
                 }
             </div>
@@ -149,6 +150,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         let creationCluster = null;
         if (creationMethods.length > 0) {
             creationCluster = (<ClusterView
+                libraryView={this.props.libraryView}
                 iconPath="src/resources/icons/library-creation.svg"
                 borderColor="#62895b" /* green */
                 childItems={creationMethods} />);
@@ -157,6 +159,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         let actionCluster = null;
         if (actionMethods.length > 0) {
             actionCluster = (<ClusterView
+                libraryView={this.props.libraryView}
                 iconPath="src/resources/icons/library-action.svg"
                 borderColor="#ad5446" /* red */
                 childItems={actionMethods} />);
@@ -165,6 +168,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         let queryCluster = null;
         if (queryMethods.length > 0) {
             queryCluster = (<ClusterView
+                libraryView={this.props.libraryView}
                 iconPath="src/resources/icons/library-query.svg"
                 borderColor="#4b9dbf" /* blue */
                 childItems={queryMethods} />);


### PR DESCRIPTION
This pull request started passing `LibraryView` along to `LibraryItem` and `ClusterView` so that they all have access to the instance of `LibraryView`. This is needed for example, when a `LibraryItem` needs to raise an event through `Reactor` that is in `LibraryView`.

@yeexinc @ellensi @fanwgwg 