### PR TITLE
Support absolute url for icon resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ The following simple HTML code illustrates the way to embed library view into an
 
             let libView = new LibraryEntryPoint.LibraryView(configuration);
             
-            libView.on("itemClicked", function(creationName) {
-                console.log(creationName);
+            libView.on("itemClicked", function(contextData) {
+                console.log(contextData);
             })
         </script>
 
@@ -92,10 +92,10 @@ libView.on("someEventName", function(data) {
 
 This event is raised when a library item is clicked. The registered event handler will be called with the following argument:
 
-- `creationName`: This is the value of `creationName` passed through [Loaded Data Types](./docs/v0.0.1/loaded-data-types.md) JSON data for the corresponding item.
+- `contextData`: This is the value of `contextData` passed through [Loaded Data Types](./docs/v0.0.1/loaded-data-types.md) JSON data for the corresponding item.
 
 ```js
-libView.on("itemClicked", function(creationName) {
-    console.log(creationName);
+libView.on("itemClicked", function(contextData) {
+    console.log(contextData);
 })
 ```

--- a/docs/LayoutSpecs.json
+++ b/docs/LayoutSpecs.json
@@ -2,7 +2,7 @@
   "elements": [
     {
       "text": "List",
-      "iconName": "Category.List.svg",
+      "iconName": "/src/resources/icons/Category.List.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
@@ -217,7 +217,7 @@
           "childElements": [
             {
               "text": "Keys",
-              "iconName": "Category.Keys.svg",
+              "iconName": "/src/resources/icons/Category.Keys.svg",
               "elementType": "category",
               "include": [
                 {
@@ -311,7 +311,7 @@
     },
     {
       "text": "Input",
-      "iconName": "Category.Input.svg",
+      "iconName": "/src/resources/icons/Category.Input.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
@@ -375,7 +375,8 @@
               "path": "DSCore.DateTime.TimeOfDay"
             },
             {
-              "path": "DSCore.DayOfWeek"
+              "path": "DSCore.DayOfWeek",
+              "pathIcon": "/src/resources/icons/DSCore.DayOfWeek.png"
             }
           ],
           "childElements": []
@@ -520,7 +521,7 @@
     },
     {
       "text": "Math",
-      "iconName": "Category.Math.svg",
+      "iconName": "/src/resources/icons/Category.Math.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
@@ -695,7 +696,7 @@
         },
         {
           "text": "Operators",
-          "iconName": "Category.Operators.svg",
+          "iconName": "/src/resources/icons/Category.Operators.svg",
           "elementType": "group",
           "include": [
             {
@@ -764,7 +765,7 @@
     },
     {
       "text": "Script",
-      "iconName": "Category.Script.svg",
+      "iconName": "/src/resources/icons/Category.Script.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
@@ -820,7 +821,7 @@
     },
     {
       "text": "Display",
-      "iconName": "Category.Display.svg",
+      "iconName": "/src/resources/icons/Category.Display.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
@@ -906,7 +907,7 @@
     },
     {
       "text": "ImportExport",
-      "iconName": "Category.ImportExport.svg",
+      "iconName": "/src/resources/icons/Category.ImportExport.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
@@ -1042,7 +1043,7 @@
     },
     {
       "text": "String",
-      "iconName": "Category.String.svg",
+      "iconName": "/src/resources/icons/Category.String.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
@@ -1155,7 +1156,7 @@
     },
     {
       "text": "Geometry",
-      "iconName": "Category.Geometry.svg",
+      "iconName": "/src/resources/icons/Category.Geometry.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
@@ -1165,28 +1166,36 @@
           "elementType": "group",
           "include": [
             {
-              "path": "Autodesk.DesignScript.Geometry.BoundingBox"
+              "path": "Autodesk.DesignScript.Geometry.BoundingBox",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.CoordinateSystem"
+              "path": "Autodesk.DesignScript.Geometry.CoordinateSystem",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Vector"
+              "path": "Autodesk.DesignScript.Geometry.Vector",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Edge"
+              "path": "Autodesk.DesignScript.Geometry.Edge",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Face"
+              "path": "Autodesk.DesignScript.Geometry.Face",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Face.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Plane"
+              "path": "Autodesk.DesignScript.Geometry.Plane",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Vertex"
+              "path": "Autodesk.DesignScript.Geometry.Vertex",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vertex.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Topology"
+              "path": "Autodesk.DesignScript.Geometry.Topology",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Topology.png"
             }
           ],
           "childElements": []
@@ -1197,10 +1206,12 @@
           "elementType": "group",
           "include": [
             {
-              "path": "Autodesk.DesignScript.Geometry.Point"
+              "path": "Autodesk.DesignScript.Geometry.Point",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.UV"
+              "path": "Autodesk.DesignScript.Geometry.UV",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.UV.png"
             }
           ],
           "childElements": []
@@ -1211,37 +1222,48 @@
           "elementType": "group",
           "include": [
             {
-              "path": "Autodesk.DesignScript.Geometry.Arc"
+              "path": "Autodesk.DesignScript.Geometry.Arc",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Circle"
+              "path": "Autodesk.DesignScript.Geometry.Circle",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Curve"
+              "path": "Autodesk.DesignScript.Geometry.Curve",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Ellipse"
+              "path": "Autodesk.DesignScript.Geometry.Ellipse",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipserc.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.EllipseArc"
+              "path": "Autodesk.DesignScript.Geometry.EllipseArc",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Helix"
+              "path": "Autodesk.DesignScript.Geometry.Helix",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Line"
+              "path": "Autodesk.DesignScript.Geometry.Line",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.NurbsCurve"
+              "path": "Autodesk.DesignScript.Geometry.NurbsCurve",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.PolyCurve"
+              "path": "Autodesk.DesignScript.Geometry.PolyCurve",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Polygon"
+              "path": "Autodesk.DesignScript.Geometry.Polygon",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Rectangle"
+              "path": "Autodesk.DesignScript.Geometry.Rectangle",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.png"
             }
           ],
           "childElements": []
@@ -1252,13 +1274,16 @@
           "elementType": "group",
           "include": [
             {
-              "path": "Autodesk.DesignScript.Geometry.NurbsSurface"
+              "path": "Autodesk.DesignScript.Geometry.NurbsSurface",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.PolySurface"
+              "path": "Autodesk.DesignScript.Geometry.PolySurface",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Surface"
+              "path": "Autodesk.DesignScript.Geometry.Surface",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.png"
             }
           ],
           "childElements": []
@@ -1269,19 +1294,24 @@
           "elementType": "group",
           "include": [
             {
-              "path": "Autodesk.DesignScript.Geometry.Cone"
+              "path": "Autodesk.DesignScript.Geometry.Cone",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Cuboid"
+              "path": "Autodesk.DesignScript.Geometry.Cuboid",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Cylinder"
+              "path": "Autodesk.DesignScript.Geometry.Cylinder",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cylinder.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Solid"
+              "path": "Autodesk.DesignScript.Geometry.Solid",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Sphere"
+              "path": "Autodesk.DesignScript.Geometry.Sphere",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.png"
             }
           ],
           "childElements": []
@@ -1292,10 +1322,12 @@
           "elementType": "group",
           "include": [
             {
-              "path": "Autodesk.DesignScript.Geometry.IndexGroup"
+              "path": "Autodesk.DesignScript.Geometry.IndexGroup",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Mesh"
+              "path": "Autodesk.DesignScript.Geometry.Mesh",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.png"
             }
           ],
           "childElements": []
@@ -1306,10 +1338,12 @@
           "elementType": "group",
           "include": [
             {
-              "path": "Geometry.Geometry"
+              "path": "Geometry.Geometry",
+              "pathIcon": "/src/resources/icons/Geometry.Geometry.png"
             },
             {
-              "path": "Autodesk.DesignScript.Geometry.Geometry"
+              "path": "Autodesk.DesignScript.Geometry.Geometry",
+              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.png"
             }
           ],
           "childElements": [
@@ -1338,13 +1372,16 @@
           "elementType": "group",
           "include": [
             {
-              "path": "Tessellation.ConvexHull"
+              "path": "Tessellation.ConvexHull",
+              "pathIcon": "/src/resources/icons/Tessellation.ConvexHull.png"
             },
             {
-              "path": "Tessellation.Delaunay"
+              "path": "Tessellation.Delaunay",
+              "pathIcon": "/src/resources/icons/Tessellation.Delaunay.png"
             },
             {
-              "path": "Tessellation.Voronoi"
+              "path": "Tessellation.Voronoi",
+              "pathIcon": "/src/resources/icons/Tessellation.Voronoi.png"
             }
           ],
           "childElements": []

--- a/docs/LayoutSpecs.json
+++ b/docs/LayoutSpecs.json
@@ -2,13 +2,13 @@
   "elements": [
     {
       "text": "List",
-      "iconName": "/src/resources/icons/Category.List.svg",
+      "iconUrl": "/src/resources/icons/Category.List.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
         {
           "text": "Inspect",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -103,7 +103,7 @@
         },
         {
           "text": "Modify",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -198,7 +198,7 @@
         },
         {
           "text": "Organize",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -217,7 +217,7 @@
           "childElements": [
             {
               "text": "Keys",
-              "iconName": "/src/resources/icons/Category.Keys.svg",
+              "iconUrl": "/src/resources/icons/Category.Keys.svg",
               "elementType": "category",
               "include": [
                 {
@@ -251,7 +251,7 @@
         },
         {
           "text": "Generate",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -286,7 +286,7 @@
         },
         {
           "text": "Match",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -311,13 +311,13 @@
     },
     {
       "text": "Input",
-      "iconName": "/src/resources/icons/Category.Input.svg",
+      "iconUrl": "/src/resources/icons/Category.Input.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
         {
           "text": "DateTime",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -376,14 +376,14 @@
             },
             {
               "path": "DSCore.DayOfWeek",
-              "pathIcon": "/src/resources/icons/DSCore.DayOfWeek.png"
+              "iconUrl": "/src/resources/icons/DSCore.DayOfWeek.png"
             }
           ],
           "childElements": []
         },
         {
           "text": "Location",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -403,7 +403,7 @@
         },
         {
           "text": "Basic",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -426,7 +426,7 @@
         },
         {
           "text": "TimeSpan",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -482,7 +482,7 @@
         },
         {
           "text": "Input",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -502,7 +502,7 @@
         },
         {
           "text": "Object",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -521,13 +521,13 @@
     },
     {
       "text": "Math",
-      "iconName": "/src/resources/icons/Category.Math.svg",
+      "iconUrl": "/src/resources/icons/Category.Math.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
         {
           "text": "Functions",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -673,7 +673,7 @@
         },
         {
           "text": "Units",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -696,7 +696,7 @@
         },
         {
           "text": "Operators",
-          "iconName": "/src/resources/icons/Category.Operators.svg",
+          "iconUrl": "/src/resources/icons/Category.Operators.svg",
           "elementType": "group",
           "include": [
             {
@@ -746,7 +746,7 @@
         },
         {
           "text": "Logic",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -765,13 +765,13 @@
     },
     {
       "text": "Script",
-      "iconName": "/src/resources/icons/Category.Script.svg",
+      "iconUrl": "/src/resources/icons/Category.Script.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
         {
           "text": "Evaluate",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -785,7 +785,7 @@
         },
         {
           "text": "Control Flow",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -802,7 +802,7 @@
         },
         {
           "text": "Editor",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -821,13 +821,13 @@
     },
     {
       "text": "Display",
-      "iconName": "/src/resources/icons/Category.Display.svg",
+      "iconUrl": "/src/resources/icons/Category.Display.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
         {
           "text": "Color",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -871,7 +871,7 @@
         },
         {
           "text": "Color Range",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -888,7 +888,7 @@
         },
         {
           "text": "Watch",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -907,13 +907,13 @@
     },
     {
       "text": "ImportExport",
-      "iconName": "/src/resources/icons/Category.ImportExport.svg",
+      "iconUrl": "/src/resources/icons/Category.ImportExport.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
         {
           "text": "File",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -984,7 +984,7 @@
         },
         {
           "text": "Image",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -1010,7 +1010,7 @@
         },
         {
           "text": "Data",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -1030,7 +1030,7 @@
         },
         {
           "text": "Web",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -1043,13 +1043,13 @@
     },
     {
       "text": "String",
-      "iconName": "/src/resources/icons/Category.String.svg",
+      "iconUrl": "/src/resources/icons/Category.String.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
         {
           "text": "Inspect",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -1081,7 +1081,7 @@
         },
         {
           "text": "Modify",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -1134,7 +1134,7 @@
         },
         {
           "text": "Generate",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
@@ -1156,200 +1156,200 @@
     },
     {
       "text": "Geometry",
-      "iconName": "/src/resources/icons/Category.Geometry.svg",
+      "iconUrl": "/src/resources/icons/Category.Geometry.svg",
       "elementType": "category",
       "include": [],
       "childElements": [
         {
           "text": "Abstract",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
               "path": "Autodesk.DesignScript.Geometry.BoundingBox",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.CoordinateSystem",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Vector",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Edge",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Face",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Face.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Face.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Plane",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Vertex",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vertex.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vertex.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Topology",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Topology.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Topology.png"
             }
           ],
           "childElements": []
         },
         {
           "text": "Points",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
               "path": "Autodesk.DesignScript.Geometry.Point",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.UV",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.UV.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.UV.png"
             }
           ],
           "childElements": []
         },
         {
           "text": "Curves",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
               "path": "Autodesk.DesignScript.Geometry.Arc",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Circle",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Curve",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Ellipse",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipserc.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipserc.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.EllipseArc",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Helix",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Line",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.NurbsCurve",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.PolyCurve",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Polygon",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Rectangle",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.png"
             }
           ],
           "childElements": []
         },
         {
           "text": "Surfaces",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
               "path": "Autodesk.DesignScript.Geometry.NurbsSurface",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.PolySurface",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Surface",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.png"
             }
           ],
           "childElements": []
         },
         {
           "text": "Solids",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
               "path": "Autodesk.DesignScript.Geometry.Cone",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Cuboid",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Cylinder",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cylinder.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cylinder.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Solid",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Sphere",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.png"
             }
           ],
           "childElements": []
         },
         {
           "text": "Meshes",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
               "path": "Autodesk.DesignScript.Geometry.IndexGroup",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Mesh",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.png"
             }
           ],
           "childElements": []
         },
         {
           "text": "Modifiers",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
               "path": "Geometry.Geometry",
-              "pathIcon": "/src/resources/icons/Geometry.Geometry.png"
+              "iconUrl": "/src/resources/icons/Geometry.Geometry.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Geometry",
-              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.png"
             }
           ],
           "childElements": [
             {
               "text": "Display",
-              "iconName": "",
+              "iconUrl": "",
               "elementType": "group",
               "include": [
                 {
@@ -1368,20 +1368,20 @@
         },
         {
           "text": "Tessellation",
-          "iconName": "",
+          "iconUrl": "",
           "elementType": "group",
           "include": [
             {
               "path": "Tessellation.ConvexHull",
-              "pathIcon": "/src/resources/icons/Tessellation.ConvexHull.png"
+              "iconUrl": "/src/resources/icons/Tessellation.ConvexHull.png"
             },
             {
               "path": "Tessellation.Delaunay",
-              "pathIcon": "/src/resources/icons/Tessellation.Delaunay.png"
+              "iconUrl": "/src/resources/icons/Tessellation.Delaunay.png"
             },
             {
               "path": "Tessellation.Voronoi",
-              "pathIcon": "/src/resources/icons/Tessellation.Voronoi.png"
+              "iconUrl": "/src/resources/icons/Tessellation.Voronoi.png"
             }
           ],
           "childElements": []

--- a/docs/LayoutSpecs.json
+++ b/docs/LayoutSpecs.json
@@ -1235,7 +1235,7 @@
             },
             {
               "path": "Autodesk.DesignScript.Geometry.Ellipse",
-              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipserc.png"
+              "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.png"
             },
             {
               "path": "Autodesk.DesignScript.Geometry.EllipseArc",

--- a/docs/RawTypeData.json
+++ b/docs/RawTypeData.json
@@ -2,4405 +2,4405 @@
   "loadedTypes": [
     {
       "fullyQualifiedName": "Core.Input.Code Block",
-      "iconName": "/src/resources/icons/Dynamo.Graph.Nodes.CodeBlockNodeModel.png",
+      "iconUrl": "/src/resources/icons/Dynamo.Graph.Nodes.CodeBlockNodeModel.png",
       "contextData": "Code Block",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Input",
-      "iconName": "/src/resources/icons/Dynamo.Graph.Nodes.CustomNodes.Symbol.png",
+      "iconUrl": "/src/resources/icons/Dynamo.Graph.Nodes.CustomNodes.Symbol.png",
       "contextData": "Input",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Output",
-      "iconName": "/src/resources/icons/Dynamo.Graph.Nodes.CustomNodes.Output.png",
+      "iconUrl": "/src/resources/icons/Dynamo.Graph.Nodes.CustomNodes.Output.png",
       "contextData": "Output",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Units.Convert Between Units",
-      "iconName": "/src/resources/icons/CoreNodeModels.DynamoConvert.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.DynamoConvert.png",
       "contextData": "Convert Between Units",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Color.Color Range",
-      "iconName": "/src/resources/icons/CoreNodeModels.ColorRange.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.ColorRange.png",
       "contextData": "Color Range",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Core.List.List.Create",
-      "iconName": "/src/resources/icons/CoreNodeModels.CreateList.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.CreateList.png",
       "contextData": "List.Create",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Core.Scripting.Formula",
-      "iconName": "/src/resources/icons/CoreNodeModels.Formula.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Formula.png",
       "contextData": "Formula",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.Range",
-      "iconName": "/src/resources/icons/CoreNodeModels.Range.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Range.png",
       "contextData": "Range",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Core.List.Sequence",
-      "iconName": "/src/resources/icons/CoreNodeModels.Sequence.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Sequence.png",
       "contextData": "Sequence",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Core.View.Watch",
-      "iconName": "/src/resources/icons/CoreNodeModels.Watch.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Watch.png",
       "contextData": "Watch",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.View.Watch Image",
-      "iconName": "/src/resources/icons/CoreNodeModels.WatchImageCore.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.WatchImageCore.png",
       "contextData": "Watch Image",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.String.String from Object",
-      "iconName": "/src/resources/icons/CoreNodeModels.FromObject.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.FromObject.png",
       "contextData": "String from Object",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.String.String from Array",
-      "iconName": "/src/resources/icons/CoreNodeModels.FromArray.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.FromArray.png",
       "contextData": "String from Array",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Web.Web Request",
-      "iconName": "/src/resources/icons/CoreNodeModels.WebRequest.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.WebRequest.png",
       "contextData": "Web Request",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Logic.And",
-      "iconName": "/src/resources/icons/CoreNodeModels.Logic.And.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Logic.And.png",
       "contextData": "And",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Logic.Or",
-      "iconName": "/src/resources/icons/CoreNodeModels.Logic.Or.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Logic.Or.png",
       "contextData": "Or",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Logic.If",
-      "iconName": "/src/resources/icons/CoreNodeModels.Logic.If.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Logic.If.png",
       "contextData": "If",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Logic.ScopeIf",
-      "iconName": "/src/resources/icons/CoreNodeModels.Logic.ScopedIf.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Logic.ScopedIf.png",
       "contextData": "ScopeIf",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Evaluate.Function.Apply",
-      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.ApplyFunction.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.HigherOrder.ApplyFunction.png",
       "contextData": "Function.Apply",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Evaluate.Function.Compose",
-      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.ComposeFunctions.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.HigherOrder.ComposeFunctions.png",
       "contextData": "Function.Compose",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.Map",
-      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.Map.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.HigherOrder.Map.png",
       "contextData": "List.Map",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.Combine",
-      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.Combine.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.HigherOrder.Combine.png",
       "contextData": "List.Combine",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.LaceShortest",
-      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.LaceShortest.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.HigherOrder.LaceShortest.png",
       "contextData": "List.LaceShortest",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.LaceLongest",
-      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.LaceLongest.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.HigherOrder.LaceLongest.png",
       "contextData": "List.LaceLongest",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.CartesianProduct",
-      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.CartesianProduct.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.HigherOrder.CartesianProduct.png",
       "contextData": "List.CartesianProduct",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.Reduce",
-      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.Reduce.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.HigherOrder.Reduce.png",
       "contextData": "List.Reduce",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.Scan",
-      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.ScanList.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.HigherOrder.ScanList.png",
       "contextData": "List.Scan",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.Filter",
-      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.Filter.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.HigherOrder.Filter.png",
       "contextData": "List.Filter",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.ReplaceByCondition",
-      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.Replace.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.HigherOrder.Replace.png",
       "contextData": "ReplaceByCondition",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Date Time",
-      "iconName": "/src/resources/icons/CoreNodeModels.Input.DateTime.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Input.DateTime.png",
       "contextData": "Date Time",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.String",
-      "iconName": "/src/resources/icons/CoreNodeModels.Input.StringInput.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Input.StringInput.png",
       "contextData": "String",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Number",
-      "iconName": "/src/resources/icons/CoreNodeModels.Input.DoubleInput.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Input.DoubleInput.png",
       "contextData": "Number",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Number Slider",
-      "iconName": "/src/resources/icons/CoreNodeModels.Input.DoubleSlider.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Input.DoubleSlider.png",
       "contextData": "Number Slider",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.File Path",
-      "iconName": "/src/resources/icons/CoreNodeModels.Input.Filename.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Input.Filename.png",
       "contextData": "File Path",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Directory Path",
-      "iconName": "/src/resources/icons/CoreNodeModels.Input.Directory.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Input.Directory.png",
       "contextData": "Directory Path",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.File.File.FromPath",
-      "iconName": "/src/resources/icons/CoreNodeModels.Input.FileObject.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Input.FileObject.png",
       "contextData": "File.FromPath",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.File.Directory.FromPath",
-      "iconName": "/src/resources/icons/CoreNodeModels.Input.DirectoryObject.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Input.DirectoryObject.png",
       "contextData": "Directory.FromPath",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Boolean",
-      "iconName": "/src/resources/icons/CoreNodeModels.Input.BoolSelector.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Input.BoolSelector.png",
       "contextData": "Boolean",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Integer Slider",
-      "iconName": "/src/resources/icons/CoreNodeModels.Input.IntegerSlider.png",
+      "iconUrl": "/src/resources/icons/CoreNodeModels.Input.IntegerSlider.png",
       "contextData": "Integer Slider",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Geometry.Geometry.ExportToSAT",
-      "iconName": "/src/resources/icons/GeometryUI.ExportWithUnits.png",
+      "iconUrl": "/src/resources/icons/GeometryUI.ExportWithUnits.png",
       "contextData": "ExportToSAT",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Scripting.Python Script",
-      "iconName": "/src/resources/icons/PythonNodeModels.PythonNode.png",
+      "iconUrl": "/src/resources/icons/PythonNodeModels.PythonNode.png",
       "contextData": "Python Script",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Scripting.Python Script From String",
-      "iconName": "/src/resources/icons/PythonNodeModels.PythonStringNode.png",
+      "iconUrl": "/src/resources/icons/PythonNodeModels.PythonStringNode.png",
       "contextData": "Python Script From String",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Units.Number From Feet and Inches",
-      "iconName": "/src/resources/icons/UnitsUI.LengthFromString.png",
+      "iconUrl": "/src/resources/icons/UnitsUI.LengthFromString.png",
       "contextData": "Number From Feet and Inches",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Units.Unit Types",
-      "iconName": "/src/resources/icons/UnitsUI.UnitTypes.png",
+      "iconUrl": "/src/resources/icons/UnitsUI.UnitTypes.png",
       "contextData": "Unit Types",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.View.Watch 3D",
-      "iconName": "/src/resources/icons/Watch3DNodeModels.Watch3D.png",
+      "iconUrl": "/src/resources/icons/Watch3DNodeModels.Watch3D.png",
       "contextData": "Watch 3D",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Count",
-      "iconName": "/src/resources/icons/Count.png",
+      "iconUrl": "/src/resources/icons/Count.png",
       "contextData": "Count@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Rank",
-      "iconName": "/src/resources/icons/Rank.png",
+      "iconUrl": "/src/resources/icons/Rank.png",
       "contextData": "Rank@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Flatten",
-      "iconName": "/src/resources/icons/Flatten.png",
+      "iconUrl": "/src/resources/icons/Flatten.png",
       "contextData": "Flatten@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "SetIntersection",
-      "iconName": "/src/resources/icons/SetIntersection.png",
+      "iconUrl": "/src/resources/icons/SetIntersection.png",
       "contextData": "SetIntersection@var[],var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "SetUnion",
-      "iconName": "/src/resources/icons/SetUnion.png",
+      "iconUrl": "/src/resources/icons/SetUnion.png",
       "contextData": "SetUnion@var[],var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "SetDifference",
-      "iconName": "/src/resources/icons/SetDifference.png",
+      "iconUrl": "/src/resources/icons/SetDifference.png",
       "contextData": "SetDifference@var[],var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "CountTrue",
-      "iconName": "/src/resources/icons/CountTrue.png",
+      "iconUrl": "/src/resources/icons/CountTrue.png",
       "contextData": "CountTrue@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "CountFalse",
-      "iconName": "/src/resources/icons/CountFalse.png",
+      "iconUrl": "/src/resources/icons/CountFalse.png",
       "contextData": "CountFalse@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "AllFalse",
-      "iconName": "/src/resources/icons/AllFalse.png",
+      "iconUrl": "/src/resources/icons/AllFalse.png",
       "contextData": "AllFalse@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "AllTrue",
-      "iconName": "/src/resources/icons/AllTrue.png",
+      "iconUrl": "/src/resources/icons/AllTrue.png",
       "contextData": "AllTrue@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "IsHomogeneous",
-      "iconName": "/src/resources/icons/IsHomogeneous.png",
+      "iconUrl": "/src/resources/icons/IsHomogeneous.png",
       "contextData": "IsHomogeneous@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "RemoveIfNot",
-      "iconName": "/src/resources/icons/RemoveIfNot.png",
+      "iconUrl": "/src/resources/icons/RemoveIfNot.png",
       "contextData": "RemoveIfNot@var[]..[],string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Equals",
-      "iconName": "/src/resources/icons/Equals.var-var.png",
+      "iconUrl": "/src/resources/icons/Equals.var-var.png",
       "contextData": "Equals@var,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Contains",
-      "iconName": "/src/resources/icons/Contains.png",
+      "iconUrl": "/src/resources/icons/Contains.png",
       "contextData": "Contains@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "IndexOf",
-      "iconName": "/src/resources/icons/IndexOf.varN-varN.png",
+      "iconUrl": "/src/resources/icons/IndexOf.varN-varN.png",
       "contextData": "IndexOf@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Insert",
-      "iconName": "/src/resources/icons/Insert.varN-var-int.png",
+      "iconUrl": "/src/resources/icons/Insert.varN-var-int.png",
       "contextData": "Insert@var[]..[],var,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Insert",
-      "iconName": "/src/resources/icons/Insert.varN-varN-int.png",
+      "iconUrl": "/src/resources/icons/Insert.varN-varN-int.png",
       "contextData": "Insert@var[]..[],var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "SortIndexByValue",
-      "iconName": "/src/resources/icons/SortIndexByValue.double1.png",
+      "iconUrl": "/src/resources/icons/SortIndexByValue.double1.png",
       "contextData": "SortIndexByValue@double[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "SortIndexByValue",
-      "iconName": "/src/resources/icons/SortIndexByValue.double1-bool.png",
+      "iconUrl": "/src/resources/icons/SortIndexByValue.double1-bool.png",
       "contextData": "SortIndexByValue@double[],bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Reorder",
-      "iconName": "/src/resources/icons/Reorder.png",
+      "iconUrl": "/src/resources/icons/Reorder.png",
       "contextData": "Reorder@var[],var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "IsUniformDepth",
-      "iconName": "/src/resources/icons/IsUniformDepth.png",
+      "iconUrl": "/src/resources/icons/IsUniformDepth.png",
       "contextData": "IsUniformDepth@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "IsRectangular",
-      "iconName": "/src/resources/icons/IsRectangular.png",
+      "iconUrl": "/src/resources/icons/IsRectangular.png",
       "contextData": "IsRectangular@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "NormalizeDepth",
-      "iconName": "/src/resources/icons/NormalizeDepth.varN.png",
+      "iconUrl": "/src/resources/icons/NormalizeDepth.varN.png",
       "contextData": "NormalizeDepth@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "NormalizeDepth",
-      "iconName": "/src/resources/icons/NormalizeDepth.varN-var.png",
+      "iconUrl": "/src/resources/icons/NormalizeDepth.varN-var.png",
       "contextData": "NormalizeDepth@var[]..[],var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Map",
-      "iconName": "/src/resources/icons/Map.png",
+      "iconUrl": "/src/resources/icons/Map.png",
       "contextData": "Map@double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "MapTo",
-      "iconName": "/src/resources/icons/MapTo.png",
+      "iconUrl": "/src/resources/icons/MapTo.png",
       "contextData": "MapTo@double,double,double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "ImportFromCSV",
-      "iconName": "/src/resources/icons/ImportFromCSV.string.png",
+      "iconUrl": "/src/resources/icons/ImportFromCSV.string.png",
       "contextData": "ImportFromCSV@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "ImportFromCSV",
-      "iconName": "/src/resources/icons/ImportFromCSV.string-bool.png",
+      "iconUrl": "/src/resources/icons/ImportFromCSV.string-bool.png",
       "contextData": "ImportFromCSV@string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "GetKeys",
-      "iconName": "/src/resources/icons/GetKeys.png",
+      "iconUrl": "/src/resources/icons/GetKeys.png",
       "contextData": "GetKeys@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "GetValues",
-      "iconName": "/src/resources/icons/GetValues.png",
+      "iconUrl": "/src/resources/icons/GetValues.png",
       "contextData": "GetValues@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "RemoveKey",
-      "iconName": "/src/resources/icons/RemoveKey.png",
+      "iconUrl": "/src/resources/icons/RemoveKey.png",
       "contextData": "RemoveKey@var[]..[],var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "ContainsKey",
-      "iconName": "/src/resources/icons/ContainsKey.png",
+      "iconUrl": "/src/resources/icons/ContainsKey.png",
       "contextData": "ContainsKey@var[]..[],var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "MinimumItemByKey",
-      "iconName": "/src/resources/icons/MinimumItemByKey.png",
+      "iconUrl": "/src/resources/icons/MinimumItemByKey.png",
       "contextData": "MinimumItemByKey@var[]..[],Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "MaximumItemByKey",
-      "iconName": "/src/resources/icons/MaximumItemByKey.png",
+      "iconUrl": "/src/resources/icons/MaximumItemByKey.png",
       "contextData": "MaximumItemByKey@var[]..[],Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "SortByFunction",
-      "iconName": "/src/resources/icons/SortByFunction.png",
+      "iconUrl": "/src/resources/icons/SortByFunction.png",
       "contextData": "SortByFunction@var[]..[],Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "GroupByFunction",
-      "iconName": "/src/resources/icons/GroupByFunction.png",
+      "iconUrl": "/src/resources/icons/GroupByFunction.png",
       "contextData": "GroupByFunction@var[]..[],Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "TrueForAll",
-      "iconName": "/src/resources/icons/TrueForAll.png",
+      "iconUrl": "/src/resources/icons/TrueForAll.png",
       "contextData": "TrueForAll@var[]..[],Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "TrueForAny",
-      "iconName": "/src/resources/icons/TrueForAny.png",
+      "iconUrl": "/src/resources/icons/TrueForAny.png",
       "contextData": "TrueForAny@var[]..[],Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "LoopWhile",
-      "iconName": "/src/resources/icons/LoopWhile.png",
+      "iconUrl": "/src/resources/icons/LoopWhile.png",
       "contextData": "LoopWhile@var[]..[],Function,Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "NewtonRootFind1DNoDeriv",
-      "iconName": "/src/resources/icons/NewtonRootFind1DNoDeriv.png",
+      "iconUrl": "/src/resources/icons/NewtonRootFind1DNoDeriv.png",
       "contextData": "NewtonRootFind1DNoDeriv@Function,double,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "NewtonRootFind1DWithDeriv",
-      "iconName": "/src/resources/icons/NewtonRootFind1DWithDeriv.png",
+      "iconUrl": "/src/resources/icons/NewtonRootFind1DWithDeriv.png",
       "contextData": "NewtonRootFind1DWithDeriv@Function,Function,double,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "+",
-      "iconName": "/src/resources/icons/add.png",
+      "iconUrl": "/src/resources/icons/add.png",
       "contextData": "+@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "-",
-      "iconName": "/src/resources/icons/sub.png",
+      "iconUrl": "/src/resources/icons/sub.png",
       "contextData": "-@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "*",
-      "iconName": "/src/resources/icons/mul.png",
+      "iconUrl": "/src/resources/icons/mul.png",
       "contextData": "*@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "/",
-      "iconName": "/src/resources/icons/div.png",
+      "iconUrl": "/src/resources/icons/div.png",
       "contextData": "/@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "==",
-      "iconName": "/src/resources/icons/eq.png",
+      "iconUrl": "/src/resources/icons/eq.png",
       "contextData": "==@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": ">=",
-      "iconName": "/src/resources/icons/ge.png",
+      "iconUrl": "/src/resources/icons/ge.png",
       "contextData": ">=@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": ">",
-      "iconName": "/src/resources/icons/gt.png",
+      "iconUrl": "/src/resources/icons/gt.png",
       "contextData": ">@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "%",
-      "iconName": "/src/resources/icons/mod.png",
+      "iconUrl": "/src/resources/icons/mod.png",
       "contextData": "%@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "<=",
-      "iconName": "/src/resources/icons/le.png",
+      "iconUrl": "/src/resources/icons/le.png",
       "contextData": "<=@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "<",
-      "iconName": "/src/resources/icons/lt.png",
+      "iconUrl": "/src/resources/icons/lt.png",
       "contextData": "<@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "&&",
-      "iconName": "/src/resources/icons/and.png",
+      "iconUrl": "/src/resources/icons/and.png",
       "contextData": "&&@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "||",
-      "iconName": "/src/resources/icons/or.png",
+      "iconUrl": "/src/resources/icons/or.png",
       "contextData": "||@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "!=",
-      "iconName": "/src/resources/icons/nq.png",
+      "iconUrl": "/src/resources/icons/nq.png",
       "contextData": "!=@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Not",
-      "iconName": "/src/resources/icons/Not.png",
+      "iconUrl": "/src/resources/icons/Not.png",
       "contextData": "Not@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByThreePoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByThreePoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByThreePoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.ByThreePoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointRadiusAngle",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByCenterPointRadiusAngle.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByCenterPointRadiusAngle.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointRadiusAngle@Autodesk.DesignScript.Geometry.Point,double,double,double,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointSweepAngle",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointSweepAngle.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointSweepAngle.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointSweepAngle@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointEndPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointEndPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointEndPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByFillet",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByFillet.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByFillet.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.ByFillet@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByFilletTangentToCurve",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByFilletTangentToCurve.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByFilletTangentToCurve.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.ByFilletTangentToCurve@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByBestFitThroughPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByBestFitThroughPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByBestFitThroughPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.ByBestFitThroughPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByStartEndAndTangencies",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByStartEndAndTangencies.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByStartEndAndTangencies.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.ByStartEndAndTangencies@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByStartPointEndPointStartTangent",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByStartPointEndPointStartTangent.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByStartPointEndPointStartTangent.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.ByStartPointEndPointStartTangent@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.CenterPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.CenterPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.CenterPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.CenterPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.Radius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.Radius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.Radius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.Radius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.StartAngle",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.StartAngle.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.StartAngle.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.StartAngle",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.SweepAngle",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.SweepAngle.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.SweepAngle.png",
       "contextData": "Autodesk.DesignScript.Geometry.Arc.SweepAngle",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ByParameterLineOnSurface",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ByParameterLineOnSurface.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ByParameterLineOnSurface.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ByParameterLineOnSurface@Autodesk.DesignScript.Geometry.Surface,Autodesk.DesignScript.Geometry.UV,Autodesk.DesignScript.Geometry.UV",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ByBlendBetweenCurves",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ByBlendBetweenCurves.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ByBlendBetweenCurves.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ByBlendBetweenCurves@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,bool,bool,bool",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ByIsoCurveOnSurface",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ByIsoCurveOnSurface.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ByIsoCurveOnSurface.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ByIsoCurveOnSurface@Autodesk.DesignScript.Geometry.Surface,int,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Length",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Length.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Length.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.Length",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.IsPlanar",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.IsPlanar.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.IsPlanar.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.IsPlanar",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.IsClosed",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.IsClosed.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.IsClosed.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.IsClosed",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.StartPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.StartPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.StartPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.StartPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.EndPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.EndPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.EndPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.EndPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Normal",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Normal.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Normal.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.Normal",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.PointAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TangentAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TangentAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TangentAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.TangentAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.NormalAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.NormalAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.NormalAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.NormalAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.HorizontalFrameAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.HorizontalFrameAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.HorizontalFrameAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.HorizontalFrameAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PlaneAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PlaneAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PlaneAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.PlaneAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointAtSegmentLength",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointAtSegmentLength.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointAtSegmentLength.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.PointAtSegmentLength@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualSegmentLength",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointsAtEqualSegmentLength.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointsAtEqualSegmentLength.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualSegmentLength@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualChordLength",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointsAtEqualChordLength.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointsAtEqualChordLength.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualChordLength@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointAtChordLength",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointAtChordLength.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointAtChordLength.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.PointAtChordLength@double,double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointsAtSegmentLengthFromPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointsAtSegmentLengthFromPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointsAtSegmentLengthFromPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.PointsAtSegmentLengthFromPoint@Autodesk.DesignScript.Geometry.Point,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointsAtChordLengthFromPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointsAtChordLengthFromPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointsAtChordLengthFromPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.PointsAtChordLengthFromPoint@Autodesk.DesignScript.Geometry.Point,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtSegmentLength",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtSegmentLength.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtSegmentLength.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtSegmentLength@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PlaneAtSegmentLength",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PlaneAtSegmentLength.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PlaneAtSegmentLength.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.PlaneAtSegmentLength@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SegmentLengthAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SegmentLengthAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SegmentLengthAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.SegmentLengthAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ParameterAtSegmentLength",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ParameterAtSegmentLength.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ParameterAtSegmentLength.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ParameterAtSegmentLength@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ParameterAtChordLength",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ParameterAtChordLength.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ParameterAtChordLength.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ParameterAtChordLength@double,double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.StartParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.StartParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.StartParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.StartParameter",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.EndParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.EndParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.EndParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.EndParameter",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SegmentLengthBetweenParameters",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SegmentLengthBetweenParameters.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SegmentLengthBetweenParameters.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.SegmentLengthBetweenParameters@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ParameterAtPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ParameterAtPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ParameterAtPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ParameterAtPoint@Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Reverse",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Reverse.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Reverse.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.Reverse",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Offset",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Offset.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Offset.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.Offset@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PullOntoPlane",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PullOntoPlane.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PullOntoPlane.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.PullOntoPlane@Autodesk.DesignScript.Geometry.Plane",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PullOntoSurface",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PullOntoSurface.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PullOntoSurface.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.PullOntoSurface@Autodesk.DesignScript.Geometry.Surface",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TrimByStartParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimByStartParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimByStartParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.TrimByStartParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TrimByEndParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimByEndParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimByEndParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.TrimByEndParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TrimByParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimByParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimByParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.TrimByParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TrimInteriorByParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimInteriorByParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimInteriorByParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.TrimInteriorByParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter.double1.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter.double1.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter@double[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter.double1-bool.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter.double1-bool.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter@double[],bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SplitByParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SplitByParameter.double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SplitByParameter.double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.SplitByParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SplitByParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SplitByParameter.double1.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SplitByParameter.double1.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.SplitByParameter@double[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SplitByPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SplitByPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SplitByPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.SplitByPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Join",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Join.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Join.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.Join@Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Extrude",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Extrude.double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Extrude.double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.Extrude@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Extrude",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Extrude.Vector.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Extrude.Vector.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.Extrude@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Extrude",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Extrude.Vector-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Extrude.Vector-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.Extrude@Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid.double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid.double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid.Vector.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid.Vector.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid.Vector-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid.Vector-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid@Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Extend",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Extend.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Extend.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.Extend@double,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ExtendStart",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtendStart.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtendStart.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ExtendStart@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ExtendEnd",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtendEnd.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtendEnd.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ExtendEnd@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ApproximateWithArcAndLineSegments",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ApproximateWithArcAndLineSegments.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ApproximateWithArcAndLineSegments.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ApproximateWithArcAndLineSegments",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ToNurbsCurve",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ToNurbsCurve.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ToNurbsCurve.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.ToNurbsCurve",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Patch",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Patch.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Patch.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.Patch",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Project",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Project.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Project.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.Project@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SweepAsSurface",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SweepAsSurface.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SweepAsSurface.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.SweepAsSurface@Autodesk.DesignScript.Geometry.Curve",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SweepAsSolid",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SweepAsSolid.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SweepAsSolid.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.SweepAsSolid@Autodesk.DesignScript.Geometry.Curve",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Simplify",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Simplify.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Simplify.png",
       "contextData": "Autodesk.DesignScript.Geometry.Curve.Simplify@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Translate",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Translate.double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Translate.double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Translate@double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Translate",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Translate.Vector.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Translate.Vector.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Translate@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Translate",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Translate.Vector-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Translate.Vector-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Translate@Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Transform",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Transform.CoordinateSystem.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Transform.CoordinateSystem.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Transform",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Transform.CoordinateSystem-CoordinateSystem.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Transform.CoordinateSystem-CoordinateSystem.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem,Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Rotate",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Rotate.Point-Vector-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Rotate.Point-Vector-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Rotate@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Rotate",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Rotate.Plane-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Rotate.Plane-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Rotate@Autodesk.DesignScript.Geometry.Plane,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Mirror",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Mirror.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Mirror.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Mirror@Autodesk.DesignScript.Geometry.Plane",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Scale",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale.double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale.double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Scale@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Scale",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale.double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale.double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Scale@double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Scale",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale.Plane-double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale.Plane-double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Scale@Autodesk.DesignScript.Geometry.Plane,double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Scale",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale.Point-Point-Point.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale.Point-Point-Point.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Scale@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Scale1D",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale1D.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale1D.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Scale1D@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Scale2D",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale2D.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale2D.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Scale2D@Autodesk.DesignScript.Geometry.Plane,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.DistanceTo",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.DistanceTo.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.DistanceTo.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.DistanceTo@Autodesk.DesignScript.Geometry.Geometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.ClosestPointTo",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ClosestPointTo.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ClosestPointTo.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.ClosestPointTo@Autodesk.DesignScript.Geometry.Geometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.DoesIntersect",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.DoesIntersect.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.DoesIntersect.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.DoesIntersect@Autodesk.DesignScript.Geometry.Geometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Intersect",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Intersect.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Intersect.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Intersect@Autodesk.DesignScript.Geometry.Geometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.IntersectAll",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.IntersectAll.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.IntersectAll.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.IntersectAll@Autodesk.DesignScript.Geometry.Geometry[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Split",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Split.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Split.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Split@Autodesk.DesignScript.Geometry.Geometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Trim",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Trim.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Trim.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Trim@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Explode",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Explode.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Explode.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.Explode",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.IsAlmostEqualTo",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.IsAlmostEqualTo.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.IsAlmostEqualTo.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.IsAlmostEqualTo@Autodesk.DesignScript.Geometry.Geometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.BoundingBox",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.BoundingBox.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.BoundingBox.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.BoundingBox",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT.var.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT.var.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT.string.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT.string.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.ExportToSAT",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ExportToSAT.Geometry1-string.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ExportToSAT.Geometry1-string.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.ExportToSAT@Autodesk.DesignScript.Geometry.Geometry[],string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB..png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB..png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB.Geometry1.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB.Geometry1.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB@Autodesk.DesignScript.Geometry.Geometry[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.DeserializeFromSAB",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.DeserializeFromSAB.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.DeserializeFromSAB.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.DeserializeFromSAB@int[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.ContextCoordinateSystem",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ContextCoordinateSystem.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ContextCoordinateSystem.png",
       "contextData": "Autodesk.DesignScript.Geometry.Geometry.ContextCoordinateSystem",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.ByGeometry",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.ByGeometry.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.ByGeometry.png",
       "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.ByGeometry@Autodesk.DesignScript.Geometry.Geometry[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.ByCorners",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.ByCorners.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.ByCorners.png",
       "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.ByCorners@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.MinPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.MinPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.MinPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.MinPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.MaxPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.MaxPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.MaxPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.MaxPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.Intersection",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.Intersection.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.Intersection.png",
       "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.Intersection@Autodesk.DesignScript.Geometry.BoundingBox",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.Intersects",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.Intersects.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.Intersects.png",
       "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.Intersects@Autodesk.DesignScript.Geometry.BoundingBox",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.IsEmpty",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.IsEmpty.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.IsEmpty.png",
       "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.IsEmpty",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.Contains",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.Contains.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.Contains.png",
       "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.Contains@Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.ToCuboid",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.ToCuboid.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.ToCuboid.png",
       "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.ToCuboid",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.ToPolySurface",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.ToPolySurface.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.ToPolySurface.png",
       "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.ToPolySurface",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Identity",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Identity.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Identity.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Identity",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByMatrix",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByMatrix.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByMatrix.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByMatrix@double[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin.double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin.double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin.double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin.double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin.Point.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin.Point.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByPlane",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByPlane.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByPlane.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByPlane@Autodesk.DesignScript.Geometry.Plane",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors.Point-Vector-Vector.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors.Point-Vector-Vector.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors.Point-Vector-Vector-Vector.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors.Point-Vector-Vector-Vector.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByCylindricalCoordinates",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByCylindricalCoordinates.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByCylindricalCoordinates.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByCylindricalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.BySphericalCoordinates",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.BySphericalCoordinates.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.BySphericalCoordinates.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.BySphericalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsSingular",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.IsSingular.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.IsSingular.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsSingular",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsScaledOrtho",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.IsScaledOrtho.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.IsScaledOrtho.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsScaledOrtho",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsUniscaledOrtho",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.IsUniscaledOrtho.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.IsUniscaledOrtho.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsUniscaledOrtho",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Determinant",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Determinant.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Determinant.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Determinant",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Origin",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Origin.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Origin.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Origin",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.XAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.XAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.XAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.XAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.YAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.YAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.YAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.YAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ZAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ZAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.XScaleFactor",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.XScaleFactor.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.XScaleFactor.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.XScaleFactor",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.YScaleFactor",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.YScaleFactor.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.YScaleFactor.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.YScaleFactor",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZScaleFactor",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ZScaleFactor.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ZScaleFactor.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZScaleFactor",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.XYPlane",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.XYPlane.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.XYPlane.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.XYPlane",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.YZPlane",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.YZPlane.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.YZPlane.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.YZPlane",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZXPlane",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ZXPlane.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ZXPlane.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZXPlane",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Inverse",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Inverse.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Inverse.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Inverse",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Mirror",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Mirror.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Mirror.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Mirror@Autodesk.DesignScript.Geometry.Plane",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.PostMultiplyBy",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.PostMultiplyBy.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.PostMultiplyBy.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.PostMultiplyBy@Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.PreMultiplyBy",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.PreMultiplyBy.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.PreMultiplyBy.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.PreMultiplyBy@Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ScaleFactor",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ScaleFactor.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ScaleFactor.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ScaleFactor",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsEqualTo",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.IsEqualTo.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.IsEqualTo.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsEqualTo@Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Translate.double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Translate.double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate@double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Translate.Vector.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Translate.Vector.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Translate.Vector-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Translate.Vector-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate@Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Transform",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Transform.CoordinateSystem.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Transform.CoordinateSystem.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Transform",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Transform.CoordinateSystem-CoordinateSystem.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Transform.CoordinateSystem-CoordinateSystem.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem,Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate.Point-Vector-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate.Point-Vector-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate.Plane-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate.Plane-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate@Autodesk.DesignScript.Geometry.Plane,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.double.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale@double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.Plane-double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.Plane-double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale@Autodesk.DesignScript.Geometry.Plane,double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.Point-Point-Point.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.Point-Point-Point.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale1D",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale1D.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale1D.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale1D@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale2D",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale2D.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale2D.png",
       "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale2D@Autodesk.DesignScript.Geometry.Plane,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.ByCoordinates.double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.ByCoordinates.double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates@double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.ByCoordinates.double-double-double-bool.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.ByCoordinates.double-double-double-bool.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates@double,double,double,bool",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.ByTwoPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.ByTwoPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.ByTwoPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.ByTwoPoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.XAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.XAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.XAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.XAxis",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.YAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.YAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.YAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.YAxis",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.ZAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.ZAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.ZAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.ZAxis",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.X",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.X.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.X.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.X",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Y",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Y.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Y.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Y",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Z",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Z.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Z.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Z",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Length",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Length.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Length.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Length",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.AsPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.AsPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.AsPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.AsPoint",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Reverse",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Reverse.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Reverse.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Reverse",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Add",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Add.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Add.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Add@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Subtract",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Subtract.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Subtract.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Subtract@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Cross",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Cross.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Cross.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Cross@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Dot",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Dot.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Dot.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Dot@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Normalized",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Normalized.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Normalized.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Normalized",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.IsParallel",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.IsParallel.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.IsParallel.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.IsParallel@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.IsAlmostEqualTo",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.IsAlmostEqualTo.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.IsAlmostEqualTo.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.IsAlmostEqualTo@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Transform",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Transform.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Transform.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Rotate",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Rotate.Vector-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Rotate.Vector-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Rotate@Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Rotate",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Rotate.Plane-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Rotate.Plane-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Rotate@Autodesk.DesignScript.Geometry.Plane,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Scale",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Scale.double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Scale.double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Scale@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Scale",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Scale.double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Scale.double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.Scale@double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.AngleWithVector",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.AngleWithVector.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.AngleWithVector.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.AngleWithVector@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.AngleAboutAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.AngleAboutAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.AngleAboutAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vector.AngleAboutAxis@Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.ByCoordinates",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.ByCoordinates.double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.ByCoordinates.double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.ByCoordinates",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.ByCoordinates.double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.ByCoordinates.double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.Origin",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Origin.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Origin.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.Origin",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.ByCartesianCoordinates",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.ByCartesianCoordinates.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.ByCartesianCoordinates.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.ByCartesianCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.ByCylindricalCoordinates",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.ByCylindricalCoordinates.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.ByCylindricalCoordinates.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.ByCylindricalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.BySphericalCoordinates",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.BySphericalCoordinates.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.BySphericalCoordinates.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.BySphericalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.PruneDuplicates",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.PruneDuplicates.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.PruneDuplicates.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.PruneDuplicates@Autodesk.DesignScript.Geometry.Point[],double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.X",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.X.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.X.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.X",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.Y",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Y.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Y.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.Y",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.Z",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Z.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Z.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.Z",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.AsVector",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.AsVector.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.AsVector.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.AsVector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.Add",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Add.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Add.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.Subtract",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Subtract.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Subtract.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.Subtract@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.Project",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Project.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Project.png",
       "contextData": "Autodesk.DesignScript.Geometry.Point.Project@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ByOriginNormal",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByOriginNormal.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByOriginNormal.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.ByOriginNormal@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ByOriginNormalXAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByOriginNormalXAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByOriginNormalXAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.ByOriginNormalXAxis@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ByOriginXAxisYAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByOriginXAxisYAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByOriginXAxisYAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.ByOriginXAxisYAxis@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ByBestFitThroughPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByBestFitThroughPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByBestFitThroughPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.ByBestFitThroughPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ByLineAndPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByLineAndPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByLineAndPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.ByLineAndPoint@Autodesk.DesignScript.Geometry.Line,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ByThreePoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByThreePoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByThreePoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.ByThreePoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.XY",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.XY.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.XY.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.XY",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.XZ",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.XZ.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.XZ.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.XZ",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.YZ",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.YZ.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.YZ.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.YZ",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.Origin",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.Origin.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.Origin.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.Origin",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.Normal",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.Normal.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.Normal.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.Normal",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.XAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.XAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.XAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.XAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.YAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.YAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.YAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.YAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ToCoordinateSystem",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ToCoordinateSystem.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ToCoordinateSystem.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.ToCoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.Offset",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.Offset.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.Offset.png",
       "contextData": "Autodesk.DesignScript.Geometry.Plane.Offset@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ByLoft",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByLoft.Curve1.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByLoft.Curve1.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ByLoft",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByLoft.Curve1-Curve1.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByLoft.Curve1-Curve1.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[],Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ByRuledLoft",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByRuledLoft.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByRuledLoft.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.ByRuledLoft@Autodesk.DesignScript.Geometry.Line[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.BySweep",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.BySweep.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.BySweep.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.BySweep@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ByPerimeterPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByPerimeterPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByPerimeterPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.ByPerimeterPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.BySweep2Rails",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.BySweep2Rails.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.BySweep2Rails.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.BySweep2Rails@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ByRevolve",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByRevolve.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByRevolve.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.ByRevolve@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ByPatch",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByPatch.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByPatch.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.ByPatch@Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Area",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Area.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Area.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.Area",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Perimeter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Perimeter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Perimeter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.Perimeter",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ClosedInU",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ClosedInU.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ClosedInU.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.ClosedInU",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ClosedInV",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ClosedInV.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ClosedInV.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.ClosedInV",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Closed",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Closed.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Closed.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.Closed",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.SubtractFrom",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.SubtractFrom.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.SubtractFrom.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.SubtractFrom@Autodesk.DesignScript.Geometry.Solid",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.UVParameterAtPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.UVParameterAtPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.UVParameterAtPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.UVParameterAtPoint@Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.TrimWithEdgeLoops",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.TrimWithEdgeLoops.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.TrimWithEdgeLoops.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.TrimWithEdgeLoops@Autodesk.DesignScript.Geometry.PolyCurve[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.NormalAtPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.NormalAtPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.NormalAtPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.NormalAtPoint@Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ToNurbsSurface",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ToNurbsSurface.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ToNurbsSurface.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.ToNurbsSurface",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ApproximateWithTolerance",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ApproximateWithTolerance.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ApproximateWithTolerance.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.ApproximateWithTolerance@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Thicken",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Thicken.double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Thicken.double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.Thicken@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Thicken",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Thicken.double-bool.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Thicken.double-bool.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.Thicken@double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Offset",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Offset.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Offset.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.Offset@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.CurvatureAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.CurvatureAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.CurvatureAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.CurvatureAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.CoordinateSystemAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.CoordinateSystemAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.CoordinateSystemAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.CoordinateSystemAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.TangentAtUParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.TangentAtUParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.TangentAtUParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.TangentAtUParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.NormalAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.NormalAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.NormalAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.NormalAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.DerivativesAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.DerivativesAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.DerivativesAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.DerivativesAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.GaussianCurvatureAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.GaussianCurvatureAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.GaussianCurvatureAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.GaussianCurvatureAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.PrincipalCurvaturesAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.PrincipalCurvaturesAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.PrincipalCurvaturesAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.PrincipalCurvaturesAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.PrincipalDirectionsAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.PrincipalDirectionsAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.PrincipalDirectionsAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.PrincipalDirectionsAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.PointAtParameter",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.PointAtParameter.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.PointAtParameter.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.PointAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.PerimeterCurves",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.PerimeterCurves.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.PerimeterCurves.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.PerimeterCurves",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.GetIsoline",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.GetIsoline.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.GetIsoline.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.GetIsoline@int,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.FlipNormalDirection",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.FlipNormalDirection.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.FlipNormalDirection.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.FlipNormalDirection",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Join",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Join.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Join.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.Join@Autodesk.DesignScript.Geometry.Surface[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ProjectInputOnto",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ProjectInputOnto.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ProjectInputOnto.png",
       "contextData": "Autodesk.DesignScript.Geometry.Surface.ProjectInputOnto@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.UV.ByCoordinates",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.UV.ByCoordinates.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.UV.ByCoordinates.png",
       "contextData": "Autodesk.DesignScript.Geometry.UV.ByCoordinates@double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.UV.U",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.UV.U.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.UV.U.png",
       "contextData": "Autodesk.DesignScript.Geometry.UV.U",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.UV.V",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.UV.V.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.UV.V.png",
       "contextData": "Autodesk.DesignScript.Geometry.UV.V",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.ByJoinedCurves",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ByJoinedCurves.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ByJoinedCurves.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.ByJoinedCurves@Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.ByPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ByPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ByPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],bool",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.ByThickeningCurve",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ByThickeningCurve.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ByThickeningCurve.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.ByThickeningCurve@Autodesk.DesignScript.Geometry.Curve,double,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.NumberOfCurves",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.NumberOfCurves.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.NumberOfCurves.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.NumberOfCurves",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.Curves",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.Curves.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.Curves.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.Curves",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.CurveAtIndex",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.CurveAtIndex.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.CurveAtIndex.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.CurveAtIndex@int,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.BasePlane",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.BasePlane.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.BasePlane.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.BasePlane",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithEllipse",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithEllipse.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithEllipse.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithEllipse@double,double,double,double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithArc",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithArc.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithArc.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithArc@double,double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLine",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLine.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLine.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLine",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLineAndTangentArcs",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLineAndTangentArcs.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLineAndTangentArcs.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLineAndTangentArcs@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.Offset",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.Offset.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.Offset.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.Offset@double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.Fillet",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.Fillet.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.Fillet.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.Fillet@double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ByJoinedSurfaces",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByJoinedSurfaces.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByJoinedSurfaces.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.ByJoinedSurfaces@Autodesk.DesignScript.Geometry.Surface[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ByLoft",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByLoft.Curve1.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByLoft.Curve1.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.ByLoft@Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ByLoft",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByLoft.Curve1-Curve1.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByLoft.Curve1-Curve1.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.ByLoft@Autodesk.DesignScript.Geometry.Curve[],Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.BySweep",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.BySweep.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.BySweep.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.BySweep@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.BySweep2Rails",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.BySweep2Rails.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.BySweep2Rails.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.BySweep2Rails@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ByRevolve",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByRevolve.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByRevolve.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.ByRevolve@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ByUnion",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByUnion.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByUnion.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.ByUnion@Autodesk.DesignScript.Geometry.Solid[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Area",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Area.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Area.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.Area",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Volume",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Volume.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Volume.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.Volume",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Centroid",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Centroid.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Centroid.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.Centroid",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Union",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Union.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Union.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.Union@Autodesk.DesignScript.Geometry.Solid",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Difference",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Difference.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Difference.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.Difference@Autodesk.DesignScript.Geometry.Solid",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.DifferenceAll",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.DifferenceAll.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.DifferenceAll.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.DifferenceAll@Autodesk.DesignScript.Geometry.Solid[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ThinShell",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ThinShell.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ThinShell.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.ThinShell@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ProjectInputOnto",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ProjectInputOnto.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ProjectInputOnto.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.ProjectInputOnto@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Fillet",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Fillet.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Fillet.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.Fillet@Autodesk.DesignScript.Geometry.Edge[],double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Chamfer",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Chamfer.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Chamfer.png",
       "contextData": "Autodesk.DesignScript.Geometry.Solid.Chamfer@Autodesk.DesignScript.Geometry.Edge[],double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints.Point1.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints.Point1.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints.Point1-int.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints.Point1-int.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints@Autodesk.DesignScript.Geometry.Point[],int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints.Point1-int-bool.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints.Point1-int-bool.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints@Autodesk.DesignScript.Geometry.Point[],int,bool",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPointsWeightsKnots",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPointsWeightsKnots.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPointsWeightsKnots.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPointsWeightsKnots@Autodesk.DesignScript.Geometry.Point[],double[],double[],int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints.Point1.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints.Point1.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints.Point1-bool.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints.Point1-bool.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],bool",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints.Point1-int.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints.Point1-int.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPointsTangents",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByPointsTangents.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByPointsTangents.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPointsTangents@Autodesk.DesignScript.Geometry.Point[],Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.Degree",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.Degree.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.Degree.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.Degree",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.IsPeriodic",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.IsPeriodic.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.IsPeriodic.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.IsPeriodic",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.IsRational",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.IsRational.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.IsRational.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.IsRational",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ControlPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ControlPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ControlPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ControlPoints",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.Knots",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.Knots.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.Knots.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.Knots",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.Weights",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.Weights.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.Weights.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.Weights",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.ByLengths.double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.ByLengths.double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths@double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.ByLengths.Point-double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.ByLengths.Point-double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths@Autodesk.DesignScript.Geometry.Point,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.ByLengths.CoordinateSystem-double-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.ByLengths.CoordinateSystem-double-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.ByCorners",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.ByCorners.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.ByCorners.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cuboid.ByCorners@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.Length",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.Length.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.Length.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cuboid.Length",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.Width",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.Width.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.Width.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cuboid.Width",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.Height",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.Height.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.Height.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cuboid.Height",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.ByLoft",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ByLoft.Curve1.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ByLoft.Curve1.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.ByLoft",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ByLoft.Curve1-Curve.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ByLoft.Curve1-Curve.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.ByLoft@Autodesk.DesignScript.Geometry.Curve[],Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.ByLoftGuides",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ByLoftGuides.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ByLoftGuides.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.ByLoftGuides@Autodesk.DesignScript.Geometry.Curve[],Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.ByJoinedSurfaces",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ByJoinedSurfaces.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ByJoinedSurfaces.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.ByJoinedSurfaces@Autodesk.DesignScript.Geometry.Surface[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.BySolid",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.BySolid.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.BySolid.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.BySolid@Autodesk.DesignScript.Geometry.Solid",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.BySweep",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.BySweep.Curve-Curve1.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.BySweep.Curve-Curve1.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.BySweep@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.BySweep",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.BySweep.Curve-Curve.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.BySweep.Curve-Curve.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.BySweep@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.Surfaces",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.Surfaces.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.Surfaces.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.Surfaces",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByLine",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByLine.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByLine.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByLine@Autodesk.DesignScript.Geometry.Line",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.UnconnectedBoundaries",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.UnconnectedBoundaries.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.UnconnectedBoundaries.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.UnconnectedBoundaries",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.ExtractSolids",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ExtractSolids.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ExtractSolids.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.ExtractSolids",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.SurfaceCount",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.SurfaceCount.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.SurfaceCount.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.SurfaceCount",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.EdgeCount",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.EdgeCount.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.EdgeCount.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.EdgeCount",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.VertexCount",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.VertexCount.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.VertexCount.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.VertexCount",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.Fillet",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.Fillet.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.Fillet.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.Fillet@Autodesk.DesignScript.Geometry.Edge[],double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.Chamfer",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.Chamfer.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.Chamfer.png",
       "contextData": "Autodesk.DesignScript.Geometry.PolySurface.Chamfer@Autodesk.DesignScript.Geometry.Edge[],double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadiusNormal",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadiusNormal.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadiusNormal.png",
       "contextData": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadiusNormal@Autodesk.DesignScript.Geometry.Point,double,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.ByPlaneRadius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByPlaneRadius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByPlaneRadius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Circle.ByPlaneRadius@Autodesk.DesignScript.Geometry.Plane,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.ByThreePoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByThreePoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByThreePoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.Circle.ByThreePoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.ByBestFitThroughPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByBestFitThroughPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByBestFitThroughPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.Circle.ByBestFitThroughPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.CenterPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.CenterPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.CenterPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Circle.CenterPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.Radius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.Radius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.Radius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Circle.Radius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Edge.CurveGeometry",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.CurveGeometry.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.CurveGeometry.png",
       "contextData": "Autodesk.DesignScript.Geometry.Edge.CurveGeometry",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Edge.AdjacentFaces",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.AdjacentFaces.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.AdjacentFaces.png",
       "contextData": "Autodesk.DesignScript.Geometry.Edge.AdjacentFaces",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Edge.StartVertex",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.StartVertex.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.StartVertex.png",
       "contextData": "Autodesk.DesignScript.Geometry.Edge.StartVertex",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Edge.EndVertex",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.EndVertex.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.EndVertex.png",
       "contextData": "Autodesk.DesignScript.Geometry.Edge.EndVertex",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vertex.PointGeometry",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vertex.PointGeometry.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vertex.PointGeometry.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vertex.PointGeometry",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vertex.AdjacentEdges",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vertex.AdjacentEdges.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vertex.AdjacentEdges.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vertex.AdjacentEdges",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vertex.AdjacentFaces",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vertex.AdjacentFaces.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vertex.AdjacentFaces.png",
       "contextData": "Autodesk.DesignScript.Geometry.Vertex.AdjacentFaces",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.ByPointsRadius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.ByPointsRadius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.ByPointsRadius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cone.ByPointsRadius@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.ByPointsRadii",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.ByPointsRadii.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.ByPointsRadii.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cone.ByPointsRadii@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadius@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadii",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadii.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadii.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadii@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.StartPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.StartPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.StartPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cone.StartPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.EndPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.EndPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.EndPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cone.EndPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.RadiusRatio",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.RadiusRatio.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.RadiusRatio.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cone.RadiusRatio",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.StartRadius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.StartRadius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.StartRadius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cone.StartRadius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.EndRadius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.EndRadius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.EndRadius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cone.EndRadius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.Height",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.Height.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.Height.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cone.Height",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Topology.Vertices",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Topology.Vertices.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Topology.Vertices.png",
       "contextData": "Autodesk.DesignScript.Geometry.Topology.Vertices",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Topology.Edges",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Topology.Edges.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Topology.Edges.png",
       "contextData": "Autodesk.DesignScript.Geometry.Topology.Edges",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Topology.Faces",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Topology.Faces.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Topology.Faces.png",
       "contextData": "Autodesk.DesignScript.Geometry.Topology.Faces",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Face.Edges",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Face.Edges.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Face.Edges.png",
       "contextData": "Autodesk.DesignScript.Geometry.Face.Edges",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Face.Vertices",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Face.Vertices.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Face.Vertices.png",
       "contextData": "Autodesk.DesignScript.Geometry.Face.Vertices",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Face.SurfaceGeometry",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Face.SurfaceGeometry.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Face.SurfaceGeometry.png",
       "contextData": "Autodesk.DesignScript.Geometry.Face.SurfaceGeometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cylinder.ByRadiusHeight",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cylinder.ByRadiusHeight.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cylinder.ByRadiusHeight.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cylinder.ByRadiusHeight@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cylinder.ByPointsRadius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cylinder.ByPointsRadius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cylinder.ByPointsRadius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cylinder.ByPointsRadius@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cylinder.Radius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cylinder.Radius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cylinder.Radius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Cylinder.Radius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.ByOriginRadii",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.ByOriginRadii.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.ByOriginRadii.png",
       "contextData": "Autodesk.DesignScript.Geometry.Ellipse.ByOriginRadii@Autodesk.DesignScript.Geometry.Point,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.ByOriginVectors",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.ByOriginVectors.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.ByOriginVectors.png",
       "contextData": "Autodesk.DesignScript.Geometry.Ellipse.ByOriginVectors@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.ByCoordinateSystemRadii",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.ByCoordinateSystemRadii.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.ByCoordinateSystemRadii.png",
       "contextData": "Autodesk.DesignScript.Geometry.Ellipse.ByCoordinateSystemRadii@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.ByPlaneRadii",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.ByPlaneRadii.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.ByPlaneRadii.png",
       "contextData": "Autodesk.DesignScript.Geometry.Ellipse.ByPlaneRadii@Autodesk.DesignScript.Geometry.Plane,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.CenterPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.CenterPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.CenterPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Ellipse.CenterPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.MajorAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.MajorAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.MajorAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.Ellipse.MajorAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.MinorAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.MinorAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.MinorAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.Ellipse.MinorAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.ByPlaneRadiiAngles",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.ByPlaneRadiiAngles.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.ByPlaneRadiiAngles.png",
       "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.ByPlaneRadiiAngles@Autodesk.DesignScript.Geometry.Plane,double,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.CenterPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.CenterPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.CenterPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.CenterPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.MajorAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.MajorAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.MajorAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.MajorAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.MinorAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.MinorAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.MinorAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.MinorAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.StartAngle",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.StartAngle.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.StartAngle.png",
       "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.StartAngle",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.SweepAngle",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.SweepAngle.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.SweepAngle.png",
       "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.SweepAngle",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.Plane",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.Plane.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.Plane.png",
       "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.Plane",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Helix.ByAxis",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.ByAxis.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.ByAxis.png",
       "contextData": "Autodesk.DesignScript.Geometry.Helix.ByAxis@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Point,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Helix.Angle",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.Angle.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.Angle.png",
       "contextData": "Autodesk.DesignScript.Geometry.Helix.Angle",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Helix.Pitch",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.Pitch.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.Pitch.png",
       "contextData": "Autodesk.DesignScript.Geometry.Helix.Pitch",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Helix.Radius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.Radius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.Radius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Helix.Radius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Helix.AxisDirection",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.AxisDirection.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.AxisDirection.png",
       "contextData": "Autodesk.DesignScript.Geometry.Helix.AxisDirection",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Helix.AxisPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.AxisPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.AxisPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Helix.AxisPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.ByIndices",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.ByIndices.int-int-int-int.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.ByIndices.int-int-int-int.png",
       "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.ByIndices@int,int,int,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.ByIndices",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.ByIndices.int-int-int.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.ByIndices.int-int-int.png",
       "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.ByIndices@int,int,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.Count",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.Count.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.Count.png",
       "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.Count",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.A",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.A.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.A.png",
       "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.A",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.B",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.B.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.B.png",
       "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.B",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.C",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.C.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.C.png",
       "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.C",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.D",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.D.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.D.png",
       "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.D",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Line.ByBestFitThroughPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.ByBestFitThroughPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.ByBestFitThroughPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.Line.ByBestFitThroughPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Line.ByTangency",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.ByTangency.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.ByTangency.png",
       "contextData": "Autodesk.DesignScript.Geometry.Line.ByTangency@Autodesk.DesignScript.Geometry.Curve,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Line.ByStartPointDirectionLength",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.ByStartPointDirectionLength.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.ByStartPointDirectionLength.png",
       "contextData": "Autodesk.DesignScript.Geometry.Line.ByStartPointDirectionLength@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Line.Direction",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.Direction.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.Direction.png",
       "contextData": "Autodesk.DesignScript.Geometry.Line.Direction",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Mesh.ByPointsFaceIndices",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.ByPointsFaceIndices.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.ByPointsFaceIndices.png",
       "contextData": "Autodesk.DesignScript.Geometry.Mesh.ByPointsFaceIndices@Autodesk.DesignScript.Geometry.Point[],Autodesk.DesignScript.Geometry.IndexGroup[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Mesh.FaceIndices",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.FaceIndices.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.FaceIndices.png",
       "contextData": "Autodesk.DesignScript.Geometry.Mesh.FaceIndices",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Mesh.VertexNormals",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.VertexNormals.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.VertexNormals.png",
       "contextData": "Autodesk.DesignScript.Geometry.Mesh.VertexNormals",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Mesh.VertexPositions",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.VertexPositions.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.VertexPositions.png",
       "contextData": "Autodesk.DesignScript.Geometry.Mesh.VertexPositions",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPoints@Autodesk.DesignScript.Geometry.Point[][],int,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangents",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangents.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangents.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangents@Autodesk.DesignScript.Geometry.Point[][],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangentsKnotsDerivatives",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangentsKnotsDerivatives.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangentsKnotsDerivatives.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangentsKnotsDerivatives@Autodesk.DesignScript.Geometry.Point[][],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],double[],double[],Autodesk.DesignScript.Geometry.Vector[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPoints@Autodesk.DesignScript.Geometry.Point[][],int,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPointsWeightsKnots",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPointsWeightsKnots.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPointsWeightsKnots.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPointsWeightsKnots@Autodesk.DesignScript.Geometry.Point[][],double[][],double[],double[],int,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.DegreeU",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.DegreeU.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.DegreeU.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.DegreeU",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.DegreeV",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.DegreeV.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.DegreeV.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.DegreeV",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsU",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsU.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsU.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsU",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsV",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsV.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsV.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsV",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInU",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInU.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInU.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInU",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInV",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInV.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInV.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInV",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.IsRational",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.IsRational.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.IsRational.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.IsRational",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.ControlPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ControlPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ControlPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.ControlPoints",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.Weights",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.Weights.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.Weights.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.Weights",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.UKnots",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.UKnots.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.UKnots.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.UKnots",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.VKnots",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.VKnots.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.VKnots.png",
       "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.VKnots",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.ByPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.ByPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.ByPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.Polygon.ByPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.RegularPolygon",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.RegularPolygon.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.RegularPolygon.png",
       "contextData": "Autodesk.DesignScript.Geometry.Polygon.RegularPolygon@Autodesk.DesignScript.Geometry.Circle,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.Points",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.Points.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.Points.png",
       "contextData": "Autodesk.DesignScript.Geometry.Polygon.Points",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.PlaneDeviation",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.PlaneDeviation.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.PlaneDeviation.png",
       "contextData": "Autodesk.DesignScript.Geometry.Polygon.PlaneDeviation",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.Corners",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.Corners.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.Corners.png",
       "contextData": "Autodesk.DesignScript.Geometry.Polygon.Corners",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.Center",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.Center.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.Center.png",
       "contextData": "Autodesk.DesignScript.Geometry.Polygon.Center",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.SelfIntersections",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.SelfIntersections.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.SelfIntersections.png",
       "contextData": "Autodesk.DesignScript.Geometry.Polygon.SelfIntersections",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.ContainmentTest",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.ContainmentTest.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.ContainmentTest.png",
       "contextData": "Autodesk.DesignScript.Geometry.Polygon.ContainmentTest@Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints.Point1.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints.Point1.png",
       "contextData": "Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints.Point-Point-Point-Point.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints.Point-Point-Point-Point.png",
       "contextData": "Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength.double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength.double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength@double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength.Plane-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength.Plane-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength@Autodesk.DesignScript.Geometry.Plane,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength.CoordinateSystem-double-double.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength.CoordinateSystem-double-double.png",
       "contextData": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.Width",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.Width.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.Width.png",
       "contextData": "Autodesk.DesignScript.Geometry.Rectangle.Width",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.Height",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.Height.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.Height.png",
       "contextData": "Autodesk.DesignScript.Geometry.Rectangle.Height",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Sphere.ByFourPoints",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.ByFourPoints.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.ByFourPoints.png",
       "contextData": "Autodesk.DesignScript.Geometry.Sphere.ByFourPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Sphere.ByBestFit",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.ByBestFit.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.ByBestFit.png",
       "contextData": "Autodesk.DesignScript.Geometry.Sphere.ByBestFit@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Sphere.CenterPoint",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.CenterPoint.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.CenterPoint.png",
       "contextData": "Autodesk.DesignScript.Geometry.Sphere.CenterPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Sphere.Radius",
-      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.Radius.png",
+      "iconUrl": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.Radius.png",
       "contextData": "Autodesk.DesignScript.Geometry.Sphere.Radius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Red",
-      "iconName": "/src/resources/icons/DSCore.Color.Red.png",
+      "iconUrl": "/src/resources/icons/DSCore.Color.Red.png",
       "contextData": "DSCore.Color.Red",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Green",
-      "iconName": "/src/resources/icons/DSCore.Color.Green.png",
+      "iconUrl": "/src/resources/icons/DSCore.Color.Green.png",
       "contextData": "DSCore.Color.Green",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Blue",
-      "iconName": "/src/resources/icons/DSCore.Color.Blue.png",
+      "iconUrl": "/src/resources/icons/DSCore.Color.Blue.png",
       "contextData": "DSCore.Color.Blue",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Alpha",
-      "iconName": "/src/resources/icons/DSCore.Color.Alpha.png",
+      "iconUrl": "/src/resources/icons/DSCore.Color.Alpha.png",
       "contextData": "DSCore.Color.Alpha",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Color.ByARGB",
-      "iconName": "/src/resources/icons/DSCore.Color.ByARGB.png",
+      "iconUrl": "/src/resources/icons/DSCore.Color.ByARGB.png",
       "contextData": "DSCore.Color.ByARGB@int,int,int,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Brightness",
-      "iconName": "/src/resources/icons/DSCore.Color.Brightness.png",
+      "iconUrl": "/src/resources/icons/DSCore.Color.Brightness.png",
       "contextData": "DSCore.Color.Brightness@DSCore.Color",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Saturation",
-      "iconName": "/src/resources/icons/DSCore.Color.Saturation.png",
+      "iconUrl": "/src/resources/icons/DSCore.Color.Saturation.png",
       "contextData": "DSCore.Color.Saturation@DSCore.Color",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Hue",
-      "iconName": "/src/resources/icons/DSCore.Color.Hue.png",
+      "iconUrl": "/src/resources/icons/DSCore.Color.Hue.png",
       "contextData": "DSCore.Color.Hue@DSCore.Color",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Components",
-      "iconName": "/src/resources/icons/DSCore.Color.Components.png",
+      "iconUrl": "/src/resources/icons/DSCore.Color.Components.png",
       "contextData": "DSCore.Color.Components@DSCore.Color",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Add",
-      "iconName": "/src/resources/icons/DSCore.Color.Add.png",
+      "iconUrl": "/src/resources/icons/DSCore.Color.Add.png",
       "contextData": "DSCore.Color.Add@DSCore.Color,DSCore.Color",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Multiply",
-      "iconName": "/src/resources/icons/DSCore.Color.Multiply.png",
+      "iconUrl": "/src/resources/icons/DSCore.Color.Multiply.png",
       "contextData": "DSCore.Color.Multiply@DSCore.Color,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Divide",
-      "iconName": "/src/resources/icons/DSCore.Color.Divide.png",
+      "iconUrl": "/src/resources/icons/DSCore.Color.Divide.png",
       "contextData": "DSCore.Color.Divide@DSCore.Color,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "DSCore.ColorRange2D.ByColorsAndParameters",
-      "iconName": "/src/resources/icons/DSCore.ColorRange2D.ByColorsAndParameters.png",
+      "iconUrl": "/src/resources/icons/DSCore.ColorRange2D.ByColorsAndParameters.png",
       "contextData": "DSCore.ColorRange2D.ByColorsAndParameters@DSCore.Color[],Autodesk.DesignScript.Geometry.UV[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "DSCore.ColorRange2D.GetColorAtParameter",
-      "iconName": "/src/resources/icons/DSCore.ColorRange2D.GetColorAtParameter.png",
+      "iconUrl": "/src/resources/icons/DSCore.ColorRange2D.GetColorAtParameter.png",
       "contextData": "DSCore.ColorRange2D.GetColorAtParameter@Autodesk.DesignScript.Geometry.UV",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.MinValue",
-      "iconName": "/src/resources/icons/DSCore.DateTime.MinValue.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.MinValue.png",
       "contextData": "DSCore.DateTime.MinValue",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.MaxValue",
-      "iconName": "/src/resources/icons/DSCore.DateTime.MaxValue.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.MaxValue.png",
       "contextData": "DSCore.DateTime.MaxValue",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.Now",
-      "iconName": "/src/resources/icons/DSCore.DateTime.Now.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.Now.png",
       "contextData": "DSCore.DateTime.Now",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.Today",
-      "iconName": "/src/resources/icons/DSCore.DateTime.Today.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.Today.png",
       "contextData": "DSCore.DateTime.Today",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.ByDate",
-      "iconName": "/src/resources/icons/DSCore.DateTime.ByDate.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.ByDate.png",
       "contextData": "DSCore.DateTime.ByDate@int,int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.ByDateAndTime",
-      "iconName": "/src/resources/icons/DSCore.DateTime.ByDateAndTime.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.ByDateAndTime.png",
       "contextData": "DSCore.DateTime.ByDateAndTime@int,int,int,int,int,int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.SubtractTimeSpan",
-      "iconName": "/src/resources/icons/DSCore.DateTime.SubtractTimeSpan.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.SubtractTimeSpan.png",
       "contextData": "DSCore.DateTime.SubtractTimeSpan@var,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.AddTimeSpan",
-      "iconName": "/src/resources/icons/DSCore.DateTime.AddTimeSpan.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.AddTimeSpan.png",
       "contextData": "DSCore.DateTime.AddTimeSpan@var,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.DaysInMonth",
-      "iconName": "/src/resources/icons/DSCore.DateTime.DaysInMonth.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.DaysInMonth.png",
       "contextData": "DSCore.DateTime.DaysInMonth@int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.IsDaylightSavingsTime",
-      "iconName": "/src/resources/icons/DSCore.DateTime.IsDaylightSavingsTime.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.IsDaylightSavingsTime.png",
       "contextData": "DSCore.DateTime.IsDaylightSavingsTime@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.IsLeapYear",
-      "iconName": "/src/resources/icons/DSCore.DateTime.IsLeapYear.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.IsLeapYear.png",
       "contextData": "DSCore.DateTime.IsLeapYear@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.FromString",
-      "iconName": "/src/resources/icons/DSCore.DateTime.FromString.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.FromString.png",
       "contextData": "DSCore.DateTime.FromString@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.Date",
-      "iconName": "/src/resources/icons/DSCore.DateTime.Date.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.Date.png",
       "contextData": "DSCore.DateTime.Date@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.Components",
-      "iconName": "/src/resources/icons/DSCore.DateTime.Components.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.Components.png",
       "contextData": "DSCore.DateTime.Components@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.DayOfWeek",
-      "iconName": "/src/resources/icons/DSCore.DateTime.DayOfWeek.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.DayOfWeek.png",
       "contextData": "DSCore.DateTime.DayOfWeek@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.DayOfYear",
-      "iconName": "/src/resources/icons/DSCore.DateTime.DayOfYear.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.DayOfYear.png",
       "contextData": "DSCore.DateTime.DayOfYear@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.TimeOfDay",
-      "iconName": "/src/resources/icons/DSCore.DateTime.TimeOfDay.png",
+      "iconUrl": "/src/resources/icons/DSCore.DateTime.TimeOfDay.png",
       "contextData": "DSCore.DateTime.TimeOfDay@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Sunday",
-      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Sunday.png",
+      "iconUrl": "/src/resources/icons/DSCore.DayOfWeek.Sunday.png",
       "contextData": "DSCore.DayOfWeek.Sunday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Monday",
-      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Monday.png",
+      "iconUrl": "/src/resources/icons/DSCore.DayOfWeek.Monday.png",
       "contextData": "DSCore.DayOfWeek.Monday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Tuesday",
-      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Tuesday.png",
+      "iconUrl": "/src/resources/icons/DSCore.DayOfWeek.Tuesday.png",
       "contextData": "DSCore.DayOfWeek.Tuesday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Wednesday",
-      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Wednesday.png",
+      "iconUrl": "/src/resources/icons/DSCore.DayOfWeek.Wednesday.png",
       "contextData": "DSCore.DayOfWeek.Wednesday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Thursday",
-      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Thursday.png",
+      "iconUrl": "/src/resources/icons/DSCore.DayOfWeek.Thursday.png",
       "contextData": "DSCore.DayOfWeek.Thursday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Friday",
-      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Friday.png",
+      "iconUrl": "/src/resources/icons/DSCore.DayOfWeek.Friday.png",
       "contextData": "DSCore.DayOfWeek.Friday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Saturday",
-      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Saturday.png",
+      "iconUrl": "/src/resources/icons/DSCore.DayOfWeek.Saturday.png",
       "contextData": "DSCore.DayOfWeek.Saturday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.ByDateDifference",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.ByDateDifference.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.ByDateDifference.png",
       "contextData": "DSCore.TimeSpan.ByDateDifference@var,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Zero",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.Zero.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.Zero.png",
       "contextData": "DSCore.TimeSpan.Zero",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.MaxValue",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.MaxValue.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.MaxValue.png",
       "contextData": "DSCore.TimeSpan.MaxValue",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.MinValue",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.MinValue.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.MinValue.png",
       "contextData": "DSCore.TimeSpan.MinValue",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Create",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.Create.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.Create.png",
       "contextData": "DSCore.TimeSpan.Create@double,double,double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Scale",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.Scale.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.Scale.png",
       "contextData": "DSCore.TimeSpan.Scale@var,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Negate",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.Negate.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.Negate.png",
       "contextData": "DSCore.TimeSpan.Negate@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Add",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.Add.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.Add.png",
       "contextData": "DSCore.TimeSpan.Add@var,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Subtract",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.Subtract.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.Subtract.png",
       "contextData": "DSCore.TimeSpan.Subtract@var,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.FromString",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.FromString.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.FromString.png",
       "contextData": "DSCore.TimeSpan.FromString@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Components",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.Components.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.Components.png",
       "contextData": "DSCore.TimeSpan.Components@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.TotalDays",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.TotalDays.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.TotalDays.png",
       "contextData": "DSCore.TimeSpan.TotalDays@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.TotalHours",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.TotalHours.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.TotalHours.png",
       "contextData": "DSCore.TimeSpan.TotalHours@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.TotalMinutes",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.TotalMinutes.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.TotalMinutes.png",
       "contextData": "DSCore.TimeSpan.TotalMinutes@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.TotalSeconds",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.TotalSeconds.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.TotalSeconds.png",
       "contextData": "DSCore.TimeSpan.TotalSeconds@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.TotalMilliseconds",
-      "iconName": "/src/resources/icons/DSCore.TimeSpan.TotalMilliseconds.png",
+      "iconUrl": "/src/resources/icons/DSCore.TimeSpan.TotalMilliseconds.png",
       "contextData": "DSCore.TimeSpan.TotalMilliseconds@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Formula.Evaluate",
-      "iconName": "/src/resources/icons/DSCore.Formula.Evaluate.png",
+      "iconUrl": "/src/resources/icons/DSCore.Formula.Evaluate.png",
       "contextData": "DSCore.Formula.Evaluate@string,string[],var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Logic.Xor",
-      "iconName": "/src/resources/icons/DSCore.Logic.Xor.png",
+      "iconUrl": "/src/resources/icons/DSCore.Logic.Xor.png",
       "contextData": "DSCore.Logic.Xor@bool,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Empty",
-      "iconName": "/src/resources/icons/DSCore.List.Empty.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Empty.png",
       "contextData": "DSCore.List.Empty",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.List.UniqueItems",
-      "iconName": "/src/resources/icons/DSCore.List.UniqueItems.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.UniqueItems.png",
       "contextData": "DSCore.List.UniqueItems@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.ContainsItem",
-      "iconName": "/src/resources/icons/DSCore.List.ContainsItem.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.ContainsItem.png",
       "contextData": "DSCore.List.ContainsItem@var[]..[],var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Reverse",
-      "iconName": "/src/resources/icons/DSCore.List.Reverse.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Reverse.png",
       "contextData": "DSCore.List.Reverse@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Sublists",
-      "iconName": "/src/resources/icons/DSCore.List.Sublists.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Sublists.png",
       "contextData": "DSCore.List.Sublists@var[]..[],var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Sort",
-      "iconName": "/src/resources/icons/DSCore.List.Sort.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Sort.png",
       "contextData": "DSCore.List.Sort@var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.MinimumItem",
-      "iconName": "/src/resources/icons/DSCore.List.MinimumItem.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.MinimumItem.png",
       "contextData": "DSCore.List.MinimumItem@var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.MaximumItem",
-      "iconName": "/src/resources/icons/DSCore.List.MaximumItem.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.MaximumItem.png",
       "contextData": "DSCore.List.MaximumItem@var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.FilterByBoolMask",
-      "iconName": "/src/resources/icons/DSCore.List.FilterByBoolMask.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.FilterByBoolMask.png",
       "contextData": "DSCore.List.FilterByBoolMask@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Deconstruct",
-      "iconName": "/src/resources/icons/DSCore.List.Deconstruct.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Deconstruct.png",
       "contextData": "DSCore.List.Deconstruct@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.SortByKey",
-      "iconName": "/src/resources/icons/DSCore.List.SortByKey.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.SortByKey.png",
       "contextData": "DSCore.List.SortByKey@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.GroupByKey",
-      "iconName": "/src/resources/icons/DSCore.List.GroupByKey.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.GroupByKey.png",
       "contextData": "DSCore.List.GroupByKey@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.AddItemToFront",
-      "iconName": "/src/resources/icons/DSCore.List.AddItemToFront.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.AddItemToFront.png",
       "contextData": "DSCore.List.AddItemToFront@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.AddItemToEnd",
-      "iconName": "/src/resources/icons/DSCore.List.AddItemToEnd.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.AddItemToEnd.png",
       "contextData": "DSCore.List.AddItemToEnd@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.TakeItems",
-      "iconName": "/src/resources/icons/DSCore.List.TakeItems.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.TakeItems.png",
       "contextData": "DSCore.List.TakeItems@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.DropItems",
-      "iconName": "/src/resources/icons/DSCore.List.DropItems.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.DropItems.png",
       "contextData": "DSCore.List.DropItems@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.ShiftIndices",
-      "iconName": "/src/resources/icons/DSCore.List.ShiftIndices.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.ShiftIndices.png",
       "contextData": "DSCore.List.ShiftIndices@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.GetItemAtIndex",
-      "iconName": "/src/resources/icons/DSCore.List.GetItemAtIndex.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.GetItemAtIndex.png",
       "contextData": "DSCore.List.GetItemAtIndex@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.ReplaceItemAtIndex",
-      "iconName": "/src/resources/icons/DSCore.List.ReplaceItemAtIndex.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.ReplaceItemAtIndex.png",
       "contextData": "DSCore.List.ReplaceItemAtIndex@var[]..[],int,var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Slice",
-      "iconName": "/src/resources/icons/DSCore.List.Slice.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Slice.png",
       "contextData": "DSCore.List.Slice@var[]..[],int,int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.RemoveItemAtIndex",
-      "iconName": "/src/resources/icons/DSCore.List.RemoveItemAtIndex.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.RemoveItemAtIndex.png",
       "contextData": "DSCore.List.RemoveItemAtIndex@var[]..[],int[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.DropEveryNthItem",
-      "iconName": "/src/resources/icons/DSCore.List.DropEveryNthItem.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.DropEveryNthItem.png",
       "contextData": "DSCore.List.DropEveryNthItem@var[]..[],int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.TakeEveryNthItem",
-      "iconName": "/src/resources/icons/DSCore.List.TakeEveryNthItem.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.TakeEveryNthItem.png",
       "contextData": "DSCore.List.TakeEveryNthItem@var[]..[],int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.IsEmpty",
-      "iconName": "/src/resources/icons/DSCore.List.IsEmpty.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.IsEmpty.png",
       "contextData": "DSCore.List.IsEmpty@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Count",
-      "iconName": "/src/resources/icons/DSCore.List.Count.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Count.png",
       "contextData": "DSCore.List.Count@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Join",
-      "iconName": "/src/resources/icons/DSCore.List.Join.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Join.png",
       "contextData": "DSCore.List.Join@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.FirstItem",
-      "iconName": "/src/resources/icons/DSCore.List.FirstItem.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.FirstItem.png",
       "contextData": "DSCore.List.FirstItem@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.RestOfItems",
-      "iconName": "/src/resources/icons/DSCore.List.RestOfItems.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.RestOfItems.png",
       "contextData": "DSCore.List.RestOfItems@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Chop",
-      "iconName": "/src/resources/icons/DSCore.List.Chop.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Chop.png",
       "contextData": "DSCore.List.Chop@var[]..[],int[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.DiagonalRight",
-      "iconName": "/src/resources/icons/DSCore.List.DiagonalRight.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.DiagonalRight.png",
       "contextData": "DSCore.List.DiagonalRight@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.DiagonalLeft",
-      "iconName": "/src/resources/icons/DSCore.List.DiagonalLeft.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.DiagonalLeft.png",
       "contextData": "DSCore.List.DiagonalLeft@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Transpose",
-      "iconName": "/src/resources/icons/DSCore.List.Transpose.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Transpose.png",
       "contextData": "DSCore.List.Transpose@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Clean",
-      "iconName": "/src/resources/icons/DSCore.List.Clean.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Clean.png",
       "contextData": "DSCore.List.Clean@var[]..[],bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.OfRepeatedItem",
-      "iconName": "/src/resources/icons/DSCore.List.OfRepeatedItem.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.OfRepeatedItem.png",
       "contextData": "DSCore.List.OfRepeatedItem@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Cycle",
-      "iconName": "/src/resources/icons/DSCore.List.Cycle.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Cycle.png",
       "contextData": "DSCore.List.Cycle@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.LastItem",
-      "iconName": "/src/resources/icons/DSCore.List.LastItem.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.LastItem.png",
       "contextData": "DSCore.List.LastItem@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Shuffle",
-      "iconName": "/src/resources/icons/DSCore.List.Shuffle.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Shuffle.png",
       "contextData": "DSCore.List.Shuffle@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Permutations",
-      "iconName": "/src/resources/icons/DSCore.List.Permutations.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Permutations.png",
       "contextData": "DSCore.List.Permutations@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Combinations",
-      "iconName": "/src/resources/icons/DSCore.List.Combinations.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Combinations.png",
       "contextData": "DSCore.List.Combinations@var[]..[],int,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.FirstIndexOf",
-      "iconName": "/src/resources/icons/DSCore.List.FirstIndexOf.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.FirstIndexOf.png",
       "contextData": "DSCore.List.FirstIndexOf@var[]..[],var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.AllIndicesOf",
-      "iconName": "/src/resources/icons/DSCore.List.AllIndicesOf.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.AllIndicesOf.png",
       "contextData": "DSCore.List.AllIndicesOf@var[]..[],var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Flatten",
-      "iconName": "/src/resources/icons/DSCore.List.Flatten.png",
+      "iconUrl": "/src/resources/icons/DSCore.List.Flatten.png",
       "contextData": "DSCore.List.Flatten@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Random",
-      "iconName": "/src/resources/icons/DSCore.Math.Random.int.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Random.int.png",
       "contextData": "DSCore.Math.Random@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Random",
-      "iconName": "/src/resources/icons/DSCore.Math.Random.double-double.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Random.double-double.png",
       "contextData": "DSCore.Math.Random@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.RandomList",
-      "iconName": "/src/resources/icons/DSCore.Math.RandomList.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.RandomList.png",
       "contextData": "DSCore.Math.RandomList@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.PiTimes2",
-      "iconName": "/src/resources/icons/DSCore.Math.PiTimes2.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.PiTimes2.png",
       "contextData": "DSCore.Math.PiTimes2",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Average",
-      "iconName": "/src/resources/icons/DSCore.Math.Average.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Average.png",
       "contextData": "DSCore.Math.Average@double[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.RemapRange",
-      "iconName": "/src/resources/icons/DSCore.Math.RemapRange.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.RemapRange.png",
       "contextData": "DSCore.Math.RemapRange@double[],double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.PI",
-      "iconName": "/src/resources/icons/DSCore.Math.PI.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.PI.png",
       "contextData": "DSCore.Math.PI",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Math.E",
-      "iconName": "/src/resources/icons/DSCore.Math.E.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.E.png",
       "contextData": "DSCore.Math.E",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Math.GoldenRatio",
-      "iconName": "/src/resources/icons/DSCore.Math.GoldenRatio.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.GoldenRatio.png",
       "contextData": "DSCore.Math.GoldenRatio",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Math.RadiansToDegrees",
-      "iconName": "/src/resources/icons/DSCore.Math.RadiansToDegrees.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.RadiansToDegrees.png",
       "contextData": "DSCore.Math.RadiansToDegrees@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.DegreesToRadians",
-      "iconName": "/src/resources/icons/DSCore.Math.DegreesToRadians.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.DegreesToRadians.png",
       "contextData": "DSCore.Math.DegreesToRadians@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Abs",
-      "iconName": "/src/resources/icons/DSCore.Math.Abs.double.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Abs.double.png",
       "contextData": "DSCore.Math.Abs@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Abs",
-      "iconName": "/src/resources/icons/DSCore.Math.Abs.int.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Abs.int.png",
       "contextData": "DSCore.Math.Abs@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Acos",
-      "iconName": "/src/resources/icons/DSCore.Math.Acos.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Acos.png",
       "contextData": "DSCore.Math.Acos@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Asin",
-      "iconName": "/src/resources/icons/DSCore.Math.Asin.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Asin.png",
       "contextData": "DSCore.Math.Asin@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Atan",
-      "iconName": "/src/resources/icons/DSCore.Math.Atan.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Atan.png",
       "contextData": "DSCore.Math.Atan@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Atan2",
-      "iconName": "/src/resources/icons/DSCore.Math.Atan2.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Atan2.png",
       "contextData": "DSCore.Math.Atan2@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Ceiling",
-      "iconName": "/src/resources/icons/DSCore.Math.Ceiling.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Ceiling.png",
       "contextData": "DSCore.Math.Ceiling@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Cos",
-      "iconName": "/src/resources/icons/DSCore.Math.Cos.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Cos.png",
       "contextData": "DSCore.Math.Cos@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Cosh",
-      "iconName": "/src/resources/icons/DSCore.Math.Cosh.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Cosh.png",
       "contextData": "DSCore.Math.Cosh@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.DivRem",
-      "iconName": "/src/resources/icons/DSCore.Math.DivRem.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.DivRem.png",
       "contextData": "DSCore.Math.DivRem@int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Exp",
-      "iconName": "/src/resources/icons/DSCore.Math.Exp.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Exp.png",
       "contextData": "DSCore.Math.Exp@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Floor",
-      "iconName": "/src/resources/icons/DSCore.Math.Floor.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Floor.png",
       "contextData": "DSCore.Math.Floor@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Log",
-      "iconName": "/src/resources/icons/DSCore.Math.Log.double.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Log.double.png",
       "contextData": "DSCore.Math.Log@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Log",
-      "iconName": "/src/resources/icons/DSCore.Math.Log.double-double.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Log.double-double.png",
       "contextData": "DSCore.Math.Log@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Log10",
-      "iconName": "/src/resources/icons/DSCore.Math.Log10.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Log10.png",
       "contextData": "DSCore.Math.Log10@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Max",
-      "iconName": "/src/resources/icons/DSCore.Math.Max.double-double.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Max.double-double.png",
       "contextData": "DSCore.Math.Max@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Max",
-      "iconName": "/src/resources/icons/DSCore.Math.Max.int-int.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Max.int-int.png",
       "contextData": "DSCore.Math.Max@int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Min",
-      "iconName": "/src/resources/icons/DSCore.Math.Min.double-double.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Min.double-double.png",
       "contextData": "DSCore.Math.Min@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Min",
-      "iconName": "/src/resources/icons/DSCore.Math.Min.int-int.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Min.int-int.png",
       "contextData": "DSCore.Math.Min@int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Pow",
-      "iconName": "/src/resources/icons/DSCore.Math.Pow.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Pow.png",
       "contextData": "DSCore.Math.Pow@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Rand",
-      "iconName": "/src/resources/icons/DSCore.Math.Rand.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Rand.png",
       "contextData": "DSCore.Math.Rand",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Round",
-      "iconName": "/src/resources/icons/DSCore.Math.Round.double.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Round.double.png",
       "contextData": "DSCore.Math.Round@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Round",
-      "iconName": "/src/resources/icons/DSCore.Math.Round.double-int.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Round.double-int.png",
       "contextData": "DSCore.Math.Round@double,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Sign",
-      "iconName": "/src/resources/icons/DSCore.Math.Sign.double.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Sign.double.png",
       "contextData": "DSCore.Math.Sign@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Sign",
-      "iconName": "/src/resources/icons/DSCore.Math.Sign.int.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Sign.int.png",
       "contextData": "DSCore.Math.Sign@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Sin",
-      "iconName": "/src/resources/icons/DSCore.Math.Sin.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Sin.png",
       "contextData": "DSCore.Math.Sin@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Sinh",
-      "iconName": "/src/resources/icons/DSCore.Math.Sinh.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Sinh.png",
       "contextData": "DSCore.Math.Sinh@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Sqrt",
-      "iconName": "/src/resources/icons/DSCore.Math.Sqrt.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Sqrt.png",
       "contextData": "DSCore.Math.Sqrt@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Tan",
-      "iconName": "/src/resources/icons/DSCore.Math.Tan.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Tan.png",
       "contextData": "DSCore.Math.Tan@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Tanh",
-      "iconName": "/src/resources/icons/DSCore.Math.Tanh.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Tanh.png",
       "contextData": "DSCore.Math.Tanh@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Sum",
-      "iconName": "/src/resources/icons/DSCore.Math.Sum.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Sum.png",
       "contextData": "DSCore.Math.Sum@double[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Factorial",
-      "iconName": "/src/resources/icons/DSCore.Math.Factorial.png",
+      "iconUrl": "/src/resources/icons/DSCore.Math.Factorial.png",
       "contextData": "DSCore.Math.Factorial@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Object.IsNull",
-      "iconName": "/src/resources/icons/DSCore.Object.IsNull.png",
+      "iconUrl": "/src/resources/icons/DSCore.Object.IsNull.png",
       "contextData": "DSCore.Object.IsNull@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Object.Identity",
-      "iconName": "/src/resources/icons/DSCore.Object.Identity.png",
+      "iconUrl": "/src/resources/icons/DSCore.Object.Identity.png",
       "contextData": "DSCore.Object.Identity@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Object.Type",
-      "iconName": "/src/resources/icons/DSCore.Object.Type.png",
+      "iconUrl": "/src/resources/icons/DSCore.Object.Type.png",
       "contextData": "DSCore.Object.Type@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.ToNumber",
-      "iconName": "/src/resources/icons/DSCore.String.ToNumber.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.ToNumber.png",
       "contextData": "DSCore.String.ToNumber@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Concat",
-      "iconName": "/src/resources/icons/DSCore.String.Concat.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.Concat.png",
       "contextData": "DSCore.String.Concat@string[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Length",
-      "iconName": "/src/resources/icons/DSCore.String.Length.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.Length.png",
       "contextData": "DSCore.String.Length@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Split",
-      "iconName": "/src/resources/icons/DSCore.String.Split.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.Split.png",
       "contextData": "DSCore.String.Split@string,string[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Join",
-      "iconName": "/src/resources/icons/DSCore.String.Join.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.Join.png",
       "contextData": "DSCore.String.Join@string,string[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.ToUpper",
-      "iconName": "/src/resources/icons/DSCore.String.ToUpper.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.ToUpper.png",
       "contextData": "DSCore.String.ToUpper@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.ToLower",
-      "iconName": "/src/resources/icons/DSCore.String.ToLower.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.ToLower.png",
       "contextData": "DSCore.String.ToLower@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.ChangeCase",
-      "iconName": "/src/resources/icons/DSCore.String.ChangeCase.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.ChangeCase.png",
       "contextData": "DSCore.String.ChangeCase@string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Substring",
-      "iconName": "/src/resources/icons/DSCore.String.Substring.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.Substring.png",
       "contextData": "DSCore.String.Substring@string,int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Contains",
-      "iconName": "/src/resources/icons/DSCore.String.Contains.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.Contains.png",
       "contextData": "DSCore.String.Contains@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.CountOccurrences",
-      "iconName": "/src/resources/icons/DSCore.String.CountOccurrences.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.CountOccurrences.png",
       "contextData": "DSCore.String.CountOccurrences@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Replace",
-      "iconName": "/src/resources/icons/DSCore.String.Replace.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.Replace.png",
       "contextData": "DSCore.String.Replace@string,string,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.EndsWith",
-      "iconName": "/src/resources/icons/DSCore.String.EndsWith.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.EndsWith.png",
       "contextData": "DSCore.String.EndsWith@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.StartsWith",
-      "iconName": "/src/resources/icons/DSCore.String.StartsWith.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.StartsWith.png",
       "contextData": "DSCore.String.StartsWith@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.TrimWhitespace",
-      "iconName": "/src/resources/icons/DSCore.String.TrimWhitespace.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.TrimWhitespace.png",
       "contextData": "DSCore.String.TrimWhitespace@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.TrimLeadingWhitespace",
-      "iconName": "/src/resources/icons/DSCore.String.TrimLeadingWhitespace.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.TrimLeadingWhitespace.png",
       "contextData": "DSCore.String.TrimLeadingWhitespace@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.TrimTrailingWhitespace",
-      "iconName": "/src/resources/icons/DSCore.String.TrimTrailingWhitespace.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.TrimTrailingWhitespace.png",
       "contextData": "DSCore.String.TrimTrailingWhitespace@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.IndexOf",
-      "iconName": "/src/resources/icons/DSCore.String.IndexOf.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.IndexOf.png",
       "contextData": "DSCore.String.IndexOf@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.AllIndicesOf",
-      "iconName": "/src/resources/icons/DSCore.String.AllIndicesOf.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.AllIndicesOf.png",
       "contextData": "DSCore.String.AllIndicesOf@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.LastIndexOf",
-      "iconName": "/src/resources/icons/DSCore.String.LastIndexOf.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.LastIndexOf.png",
       "contextData": "DSCore.String.LastIndexOf@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.PadLeft",
-      "iconName": "/src/resources/icons/DSCore.String.PadLeft.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.PadLeft.png",
       "contextData": "DSCore.String.PadLeft@string,int,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.PadRight",
-      "iconName": "/src/resources/icons/DSCore.String.PadRight.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.PadRight.png",
       "contextData": "DSCore.String.PadRight@string,int,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Center",
-      "iconName": "/src/resources/icons/DSCore.String.Center.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.Center.png",
       "contextData": "DSCore.String.Center@string,int,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Insert",
-      "iconName": "/src/resources/icons/DSCore.String.Insert.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.Insert.png",
       "contextData": "DSCore.String.Insert@string,int,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Remove",
-      "iconName": "/src/resources/icons/DSCore.String.Remove.png",
+      "iconUrl": "/src/resources/icons/DSCore.String.Remove.png",
       "contextData": "DSCore.String.Remove@string,int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Thread.Pause",
-      "iconName": "/src/resources/icons/DSCore.Thread.Pause.png",
+      "iconUrl": "/src/resources/icons/DSCore.Thread.Pause.png",
       "contextData": "DSCore.Thread.Pause@var,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.FilePath.Combine",
-      "iconName": "/src/resources/icons/DSCore.IO.FilePath.Combine.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.FilePath.Combine.png",
       "contextData": "DSCore.IO.FilePath.Combine@string[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.FilePath.Extension",
-      "iconName": "/src/resources/icons/DSCore.IO.FilePath.Extension.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.FilePath.Extension.png",
       "contextData": "DSCore.IO.FilePath.Extension@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.FilePath.ChangeExtension",
-      "iconName": "/src/resources/icons/DSCore.IO.FilePath.ChangeExtension.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.FilePath.ChangeExtension.png",
       "contextData": "DSCore.IO.FilePath.ChangeExtension@string,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.FilePath.DirectoryName",
-      "iconName": "/src/resources/icons/DSCore.IO.FilePath.DirectoryName.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.FilePath.DirectoryName.png",
       "contextData": "DSCore.IO.FilePath.DirectoryName@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.FilePath.FileName",
-      "iconName": "/src/resources/icons/DSCore.IO.FilePath.FileName.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.FilePath.FileName.png",
       "contextData": "DSCore.IO.FilePath.FileName@string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.FilePath.HasExtension",
-      "iconName": "/src/resources/icons/DSCore.IO.FilePath.HasExtension.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.FilePath.HasExtension.png",
       "contextData": "DSCore.IO.FilePath.HasExtension@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.File.ReadText",
-      "iconName": "/src/resources/icons/DSCore.IO.File.ReadText.var.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.File.ReadText.var.png",
       "contextData": "DSCore.IO.File.ReadText@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.File.Move",
-      "iconName": "/src/resources/icons/DSCore.IO.File.Move.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.File.Move.png",
       "contextData": "DSCore.IO.File.Move@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.File.Delete",
-      "iconName": "/src/resources/icons/DSCore.IO.File.Delete.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.File.Delete.png",
       "contextData": "DSCore.IO.File.Delete@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.File.Copy",
-      "iconName": "/src/resources/icons/DSCore.IO.File.Copy.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.File.Copy.png",
       "contextData": "DSCore.IO.File.Copy@var,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.File.Exists",
-      "iconName": "/src/resources/icons/DSCore.IO.File.Exists.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.File.Exists.png",
       "contextData": "DSCore.IO.File.Exists@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.File.WriteText",
-      "iconName": "/src/resources/icons/DSCore.IO.File.WriteText.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.File.WriteText.png",
       "contextData": "DSCore.IO.File.WriteText@string,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Directory.Move",
-      "iconName": "/src/resources/icons/DSCore.IO.Directory.Move.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.Directory.Move.png",
       "contextData": "DSCore.IO.Directory.Move@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Directory.Copy",
-      "iconName": "/src/resources/icons/DSCore.IO.Directory.Copy.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.Directory.Copy.png",
       "contextData": "DSCore.IO.Directory.Copy@var,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Directory.Delete",
-      "iconName": "/src/resources/icons/DSCore.IO.Directory.Delete.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.Directory.Delete.png",
       "contextData": "DSCore.IO.Directory.Delete@string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Directory.Contents",
-      "iconName": "/src/resources/icons/DSCore.IO.Directory.Contents.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.Directory.Contents.png",
       "contextData": "DSCore.IO.Directory.Contents@var,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Directory.Exists",
-      "iconName": "/src/resources/icons/DSCore.IO.Directory.Exists.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.Directory.Exists.png",
       "contextData": "DSCore.IO.Directory.Exists@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Image.ReadFromFile",
-      "iconName": "/src/resources/icons/DSCore.IO.Image.ReadFromFile.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.Image.ReadFromFile.png",
       "contextData": "DSCore.IO.Image.ReadFromFile@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Image.Pixels",
-      "iconName": "/src/resources/icons/DSCore.IO.Image.Pixels.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.Image.Pixels.png",
       "contextData": "DSCore.IO.Image.Pixels@var,int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Image.FromPixels",
-      "iconName": "/src/resources/icons/DSCore.IO.Image.FromPixels.Color2.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.Image.FromPixels.Color2.png",
       "contextData": "DSCore.IO.Image.FromPixels@DSCore.Color[][]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Image.FromPixels",
-      "iconName": "/src/resources/icons/DSCore.IO.Image.FromPixels.Color1-int-int.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.Image.FromPixels.Color1-int-int.png",
       "contextData": "DSCore.IO.Image.FromPixels@DSCore.Color[],int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Image.Dimensions",
-      "iconName": "/src/resources/icons/DSCore.IO.Image.Dimensions.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.Image.Dimensions.png",
       "contextData": "DSCore.IO.Image.Dimensions@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Image.WriteToFile",
-      "iconName": "/src/resources/icons/DSCore.IO.Image.WriteToFile.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.Image.WriteToFile.png",
       "contextData": "DSCore.IO.Image.WriteToFile@string,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.CSV.WriteToFile",
-      "iconName": "/src/resources/icons/DSCore.IO.CSV.WriteToFile.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.CSV.WriteToFile.png",
       "contextData": "DSCore.IO.CSV.WriteToFile@string,var[][]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.CSV.ReadFromFile",
-      "iconName": "/src/resources/icons/DSCore.IO.CSV.ReadFromFile.png",
+      "iconUrl": "/src/resources/icons/DSCore.IO.CSV.ReadFromFile.png",
       "contextData": "DSCore.IO.CSV.ReadFromFile@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSOffice.Excel.ReadFromFile",
-      "iconName": "/src/resources/icons/DSOffice.Excel.ReadFromFile.png",
+      "iconUrl": "/src/resources/icons/DSOffice.Excel.ReadFromFile.png",
       "contextData": "DSOffice.Excel.ReadFromFile@var,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSOffice.Excel.WriteToFile",
-      "iconName": "/src/resources/icons/DSOffice.Excel.WriteToFile.png",
+      "iconUrl": "/src/resources/icons/DSOffice.Excel.WriteToFile.png",
       "contextData": "DSOffice.Excel.WriteToFile@string,string,int,int,var[][],bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DynamoUnits.Location.Name",
-      "iconName": "/src/resources/icons/DynamoUnits.Location.Name.png",
+      "iconUrl": "/src/resources/icons/DynamoUnits.Location.Name.png",
       "contextData": "DynamoUnits.Location.Name",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DynamoUnits.Location.Latitude",
-      "iconName": "/src/resources/icons/DynamoUnits.Location.Latitude.png",
+      "iconUrl": "/src/resources/icons/DynamoUnits.Location.Latitude.png",
       "contextData": "DynamoUnits.Location.Latitude",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DynamoUnits.Location.Longitude",
-      "iconName": "/src/resources/icons/DynamoUnits.Location.Longitude.png",
+      "iconUrl": "/src/resources/icons/DynamoUnits.Location.Longitude.png",
       "contextData": "DynamoUnits.Location.Longitude",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DynamoUnits.Location.ByLatitudeAndLongitude",
-      "iconName": "/src/resources/icons/DynamoUnits.Location.ByLatitudeAndLongitude.png",
+      "iconUrl": "/src/resources/icons/DynamoUnits.Location.ByLatitudeAndLongitude.png",
       "contextData": "DynamoUnits.Location.ByLatitudeAndLongitude@double,double,string",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Tessellation.ConvexHull.ByPoints",
-      "iconName": "/src/resources/icons/Tessellation.ConvexHull.ByPoints.png",
+      "iconUrl": "/src/resources/icons/Tessellation.ConvexHull.ByPoints.png",
       "contextData": "Tessellation.ConvexHull.ByPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Tessellation.Delaunay.ByParametersOnSurface",
-      "iconName": "/src/resources/icons/Tessellation.Delaunay.ByParametersOnSurface.png",
+      "iconUrl": "/src/resources/icons/Tessellation.Delaunay.ByParametersOnSurface.png",
       "contextData": "Tessellation.Delaunay.ByParametersOnSurface@Autodesk.DesignScript.Geometry.UV[],Autodesk.DesignScript.Geometry.Surface",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Tessellation.Delaunay.ByPoints",
-      "iconName": "/src/resources/icons/Tessellation.Delaunay.ByPoints.png",
+      "iconUrl": "/src/resources/icons/Tessellation.Delaunay.ByPoints.png",
       "contextData": "Tessellation.Delaunay.ByPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Tessellation.Voronoi.ByParametersOnSurface",
-      "iconName": "/src/resources/icons/Tessellation.Voronoi.ByParametersOnSurface.png",
+      "iconUrl": "/src/resources/icons/Tessellation.Voronoi.ByParametersOnSurface.png",
       "contextData": "Tessellation.Voronoi.ByParametersOnSurface@Autodesk.DesignScript.Geometry.UV[],Autodesk.DesignScript.Geometry.Surface",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Analysis.Label.ByPointAndString",
-      "iconName": "/src/resources/icons/Analysis.Label.ByPointAndString.png",
+      "iconUrl": "/src/resources/icons/Analysis.Label.ByPointAndString.png",
       "contextData": "Analysis.Label.ByPointAndString@Autodesk.DesignScript.Geometry.Point,string",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Analysis.AnalysisExtensions.IsAlmostEqualTo",
-      "iconName": "/src/resources/icons/Analysis.AnalysisExtensions.IsAlmostEqualTo.png",
+      "iconUrl": "/src/resources/icons/Analysis.AnalysisExtensions.IsAlmostEqualTo.png",
       "contextData": "Analysis.AnalysisExtensions.IsAlmostEqualTo@Autodesk.DesignScript.Geometry.UV,Autodesk.DesignScript.Geometry.UV",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Display.Display.ByGeometryColor",
-      "iconName": "/src/resources/icons/Display.Display.ByGeometryColor.png",
+      "iconUrl": "/src/resources/icons/Display.Display.ByGeometryColor.png",
       "contextData": "Display.Display.ByGeometryColor@Autodesk.DesignScript.Geometry.Geometry,DSCore.Color",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Display.Display.BySurfaceColors",
-      "iconName": "/src/resources/icons/Display.Display.BySurfaceColors.png",
+      "iconUrl": "/src/resources/icons/Display.Display.BySurfaceColors.png",
       "contextData": "Display.Display.BySurfaceColors@Autodesk.DesignScript.Geometry.Surface,DSCore.Color[][]",
       "itemType": "creation"
     }

--- a/docs/RawTypeData.json
+++ b/docs/RawTypeData.json
@@ -2,4413 +2,4407 @@
   "loadedTypes": [
     {
       "fullyQualifiedName": "Core.Input.Code Block",
-      "iconName": "Dynamo.Graph.Nodes.CodeBlockNodeModel",
-      "creationName": "Code Block",
+      "iconName": "/src/resources/icons/Dynamo.Graph.Nodes.CodeBlockNodeModel.png",
+      "contextData": "Code Block",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Input",
-      "iconName": "Dynamo.Graph.Nodes.CustomNodes.Symbol",
-      "creationName": "Input",
+      "iconName": "/src/resources/icons/Dynamo.Graph.Nodes.CustomNodes.Symbol.png",
+      "contextData": "Input",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Output",
-      "iconName": "Dynamo.Graph.Nodes.CustomNodes.Output",
-      "creationName": "Output",
+      "iconName": "/src/resources/icons/Dynamo.Graph.Nodes.CustomNodes.Output.png",
+      "contextData": "Output",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Units.Convert Between Units",
-      "iconName": "CoreNodeModels.DynamoConvert",
-      "creationName": "Convert Between Units",
+      "iconName": "/src/resources/icons/CoreNodeModels.DynamoConvert.png",
+      "contextData": "Convert Between Units",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Color.Color Range",
-      "iconName": "CoreNodeModels.ColorRange",
-      "creationName": "Color Range",
+      "iconName": "/src/resources/icons/CoreNodeModels.ColorRange.png",
+      "contextData": "Color Range",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Core.List.List.Create",
-      "iconName": "Core.List.List.Create",
-      "creationName": "List.Create",
+      "iconName": "/src/resources/icons/CoreNodeModels.CreateList.png",
+      "contextData": "List.Create",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Core.Scripting.Formula",
-      "iconName": "CoreNodeModels.Formula",
-      "creationName": "Formula",
+      "iconName": "/src/resources/icons/CoreNodeModels.Formula.png",
+      "contextData": "Formula",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.Range",
-      "iconName": "Core.List.Range",
-      "creationName": "Range",
+      "iconName": "/src/resources/icons/CoreNodeModels.Range.png",
+      "contextData": "Range",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Core.List.Sequence",
-      "iconName": "Core.List.Sequence",
-      "creationName": "Sequence",
+      "iconName": "/src/resources/icons/CoreNodeModels.Sequence.png",
+      "contextData": "Sequence",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Core.View.Watch",
-      "iconName": "CoreNodeModels.Watch",
-      "creationName": "Watch",
+      "iconName": "/src/resources/icons/CoreNodeModels.Watch.png",
+      "contextData": "Watch",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.View.Watch Image",
-      "iconName": "CoreNodeModels.WatchImageCore",
-      "creationName": "Watch Image",
+      "iconName": "/src/resources/icons/CoreNodeModels.WatchImageCore.png",
+      "contextData": "Watch Image",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.String.String from Object",
-      "iconName": "CoreNodeModels.FromObject",
-      "creationName": "String from Object",
+      "iconName": "/src/resources/icons/CoreNodeModels.FromObject.png",
+      "contextData": "String from Object",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.String.String from Array",
-      "iconName": "CoreNodeModels.FromArray",
-      "creationName": "String from Array",
+      "iconName": "/src/resources/icons/CoreNodeModels.FromArray.png",
+      "contextData": "String from Array",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Web.Web Request",
-      "iconName": "CoreNodeModels.WebRequest",
-      "creationName": "Web Request",
+      "iconName": "/src/resources/icons/CoreNodeModels.WebRequest.png",
+      "contextData": "Web Request",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Logic.And",
-      "iconName": "CoreNodeModels.Logic.And",
-      "creationName": "And",
+      "iconName": "/src/resources/icons/CoreNodeModels.Logic.And.png",
+      "contextData": "And",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Logic.Or",
-      "iconName": "CoreNodeModels.Logic.Or",
-      "creationName": "Or",
+      "iconName": "/src/resources/icons/CoreNodeModels.Logic.Or.png",
+      "contextData": "Or",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Logic.If",
-      "iconName": "CoreNodeModels.Logic.If",
-      "creationName": "If",
+      "iconName": "/src/resources/icons/CoreNodeModels.Logic.If.png",
+      "contextData": "If",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Logic.ScopeIf",
-      "iconName": "CoreNodeModels.Logic.ScopedIf",
-      "creationName": "ScopeIf",
+      "iconName": "/src/resources/icons/CoreNodeModels.Logic.ScopedIf.png",
+      "contextData": "ScopeIf",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Evaluate.Function.Apply",
-      "iconName": "CoreNodeModels.HigherOrder.ApplyFunction",
-      "creationName": "Function.Apply",
+      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.ApplyFunction.png",
+      "contextData": "Function.Apply",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Evaluate.Function.Compose",
-      "iconName": "CoreNodeModels.HigherOrder.ComposeFunctions",
-      "creationName": "Function.Compose",
+      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.ComposeFunctions.png",
+      "contextData": "Function.Compose",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.Map",
-      "iconName": "CoreNodeModels.HigherOrder.Map",
-      "creationName": "List.Map",
+      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.Map.png",
+      "contextData": "List.Map",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.Combine",
-      "iconName": "CoreNodeModels.HigherOrder.Combine",
-      "creationName": "List.Combine",
+      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.Combine.png",
+      "contextData": "List.Combine",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.LaceShortest",
-      "iconName": "CoreNodeModels.HigherOrder.LaceShortest",
-      "creationName": "List.LaceShortest",
+      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.LaceShortest.png",
+      "contextData": "List.LaceShortest",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.LaceLongest",
-      "iconName": "CoreNodeModels.HigherOrder.LaceLongest",
-      "creationName": "List.LaceLongest",
+      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.LaceLongest.png",
+      "contextData": "List.LaceLongest",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.CartesianProduct",
-      "iconName": "CoreNodeModels.HigherOrder.CartesianProduct",
-      "creationName": "List.CartesianProduct",
+      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.CartesianProduct.png",
+      "contextData": "List.CartesianProduct",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.Reduce",
-      "iconName": "CoreNodeModels.HigherOrder.Reduce",
-      "creationName": "List.Reduce",
+      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.Reduce.png",
+      "contextData": "List.Reduce",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.Scan",
-      "iconName": "CoreNodeModels.HigherOrder.ScanList",
-      "creationName": "List.Scan",
+      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.ScanList.png",
+      "contextData": "List.Scan",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.List.Filter",
-      "iconName": "CoreNodeModels.HigherOrder.Filter",
-      "creationName": "List.Filter",
+      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.Filter.png",
+      "contextData": "List.Filter",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.List.ReplaceByCondition",
-      "iconName": "CoreNodeModels.HigherOrder.Replace",
-      "creationName": "ReplaceByCondition",
+      "iconName": "/src/resources/icons/CoreNodeModels.HigherOrder.Replace.png",
+      "contextData": "ReplaceByCondition",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Date Time",
-      "iconName": "CoreNodeModels.Input.DateTime",
-      "creationName": "Date Time",
+      "iconName": "/src/resources/icons/CoreNodeModels.Input.DateTime.png",
+      "contextData": "Date Time",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.String",
-      "iconName": "CoreNodeModels.Input.StringInput",
-      "creationName": "String",
+      "iconName": "/src/resources/icons/CoreNodeModels.Input.StringInput.png",
+      "contextData": "String",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Number",
-      "iconName": "CoreNodeModels.Input.DoubleInput",
-      "creationName": "Number",
+      "iconName": "/src/resources/icons/CoreNodeModels.Input.DoubleInput.png",
+      "contextData": "Number",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Number Slider",
-      "iconName": "CoreNodeModels.Input.DoubleSlider",
-      "creationName": "Number Slider",
+      "iconName": "/src/resources/icons/CoreNodeModels.Input.DoubleSlider.png",
+      "contextData": "Number Slider",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.File Path",
-      "iconName": "CoreNodeModels.Input.Filename",
-      "creationName": "File Path",
+      "iconName": "/src/resources/icons/CoreNodeModels.Input.Filename.png",
+      "contextData": "File Path",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Directory Path",
-      "iconName": "CoreNodeModels.Input.Directory",
-      "creationName": "Directory Path",
+      "iconName": "/src/resources/icons/CoreNodeModels.Input.Directory.png",
+      "contextData": "Directory Path",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.File.File.FromPath",
-      "iconName": "CoreNodeModels.Input.FileObject",
-      "creationName": "File.FromPath",
+      "iconName": "/src/resources/icons/CoreNodeModels.Input.FileObject.png",
+      "contextData": "File.FromPath",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.File.Directory.FromPath",
-      "iconName": "CoreNodeModels.Input.DirectoryObject",
-      "creationName": "Directory.FromPath",
+      "iconName": "/src/resources/icons/CoreNodeModels.Input.DirectoryObject.png",
+      "contextData": "Directory.FromPath",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Boolean",
-      "iconName": "CoreNodeModels.Input.BoolSelector",
-      "creationName": "Boolean",
+      "iconName": "/src/resources/icons/CoreNodeModels.Input.BoolSelector.png",
+      "contextData": "Boolean",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Integer Slider",
-      "iconName": "CoreNodeModels.Input.IntegerSlider",
-      "creationName": "Integer Slider",
+      "iconName": "/src/resources/icons/CoreNodeModels.Input.IntegerSlider.png",
+      "contextData": "Integer Slider",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Geometry.Geometry.ExportToSAT",
-      "iconName": "GeometryUI.ExportWithUnits",
-      "creationName": "ExportToSAT",
+      "iconName": "/src/resources/icons/GeometryUI.ExportWithUnits.png",
+      "contextData": "ExportToSAT",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Scripting.Python Script",
-      "iconName": "PythonNodeModels.PythonNode",
-      "creationName": "Python Script",
+      "iconName": "/src/resources/icons/PythonNodeModels.PythonNode.png",
+      "contextData": "Python Script",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Scripting.Python Script From String",
-      "iconName": "PythonNodeModels.PythonStringNode",
-      "creationName": "Python Script From String",
+      "iconName": "/src/resources/icons/PythonNodeModels.PythonStringNode.png",
+      "contextData": "Python Script From String",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Units.Number From Feet and Inches",
-      "iconName": "UnitsUI.LengthFromString",
-      "creationName": "Number From Feet and Inches",
+      "iconName": "/src/resources/icons/UnitsUI.LengthFromString.png",
+      "contextData": "Number From Feet and Inches",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Units.Unit Types",
-      "iconName": "UnitsUI.UnitTypes",
-      "creationName": "Unit Types",
+      "iconName": "/src/resources/icons/UnitsUI.UnitTypes.png",
+      "contextData": "Unit Types",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.View.Watch 3D",
-      "iconName": "Watch3DNodeModels.Watch3D",
-      "creationName": "Watch 3D",
+      "iconName": "/src/resources/icons/Watch3DNodeModels.Watch3D.png",
+      "contextData": "Watch 3D",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Count",
-      "iconName": "Count",
-      "creationName": "Count@var[]..[]",
+      "iconName": "/src/resources/icons/Count.png",
+      "contextData": "Count@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Rank",
-      "iconName": "Rank",
-      "creationName": "Rank@var[]..[]",
+      "iconName": "/src/resources/icons/Rank.png",
+      "contextData": "Rank@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Flatten",
-      "iconName": "Flatten",
-      "creationName": "Flatten@var[]..[]",
+      "iconName": "/src/resources/icons/Flatten.png",
+      "contextData": "Flatten@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "SetIntersection",
-      "iconName": "SetIntersection",
-      "creationName": "SetIntersection@var[],var[]",
+      "iconName": "/src/resources/icons/SetIntersection.png",
+      "contextData": "SetIntersection@var[],var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "SetUnion",
-      "iconName": "SetUnion",
-      "creationName": "SetUnion@var[],var[]",
+      "iconName": "/src/resources/icons/SetUnion.png",
+      "contextData": "SetUnion@var[],var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "SetDifference",
-      "iconName": "SetDifference",
-      "creationName": "SetDifference@var[],var[]",
+      "iconName": "/src/resources/icons/SetDifference.png",
+      "contextData": "SetDifference@var[],var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "CountTrue",
-      "iconName": "CountTrue",
-      "creationName": "CountTrue@var[]..[]",
+      "iconName": "/src/resources/icons/CountTrue.png",
+      "contextData": "CountTrue@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "CountFalse",
-      "iconName": "CountFalse",
-      "creationName": "CountFalse@var[]..[]",
+      "iconName": "/src/resources/icons/CountFalse.png",
+      "contextData": "CountFalse@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "AllFalse",
-      "iconName": "AllFalse",
-      "creationName": "AllFalse@var[]..[]",
+      "iconName": "/src/resources/icons/AllFalse.png",
+      "contextData": "AllFalse@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "AllTrue",
-      "iconName": "AllTrue",
-      "creationName": "AllTrue@var[]..[]",
+      "iconName": "/src/resources/icons/AllTrue.png",
+      "contextData": "AllTrue@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "IsHomogeneous",
-      "iconName": "IsHomogeneous",
-      "creationName": "IsHomogeneous@var[]..[]",
+      "iconName": "/src/resources/icons/IsHomogeneous.png",
+      "contextData": "IsHomogeneous@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "RemoveIfNot",
-      "iconName": "RemoveIfNot",
-      "creationName": "RemoveIfNot@var[]..[],string",
+      "iconName": "/src/resources/icons/RemoveIfNot.png",
+      "contextData": "RemoveIfNot@var[]..[],string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Equals",
-      "iconName": "Equals.var-var",
-      "creationName": "Equals@var,var",
+      "iconName": "/src/resources/icons/Equals.var-var.png",
+      "contextData": "Equals@var,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Contains",
-      "iconName": "Contains",
-      "creationName": "Contains@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/Contains.png",
+      "contextData": "Contains@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "IndexOf",
-      "iconName": "IndexOf.varN-varN",
-      "creationName": "IndexOf@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/IndexOf.varN-varN.png",
+      "contextData": "IndexOf@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Insert",
-      "iconName": "Insert.varN-var-int",
-      "creationName": "Insert@var[]..[],var,int",
+      "iconName": "/src/resources/icons/Insert.varN-var-int.png",
+      "contextData": "Insert@var[]..[],var,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Insert",
-      "iconName": "Insert.varN-varN-int",
-      "creationName": "Insert@var[]..[],var[]..[],int",
+      "iconName": "/src/resources/icons/Insert.varN-varN-int.png",
+      "contextData": "Insert@var[]..[],var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "SortIndexByValue",
-      "iconName": "SortIndexByValue.double1",
-      "creationName": "SortIndexByValue@double[]",
+      "iconName": "/src/resources/icons/SortIndexByValue.double1.png",
+      "contextData": "SortIndexByValue@double[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "SortIndexByValue",
-      "iconName": "SortIndexByValue.double1-bool",
-      "creationName": "SortIndexByValue@double[],bool",
+      "iconName": "/src/resources/icons/SortIndexByValue.double1-bool.png",
+      "contextData": "SortIndexByValue@double[],bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Reorder",
-      "iconName": "Reorder",
-      "creationName": "Reorder@var[],var[]",
+      "iconName": "/src/resources/icons/Reorder.png",
+      "contextData": "Reorder@var[],var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "IsUniformDepth",
-      "iconName": "IsUniformDepth",
-      "creationName": "IsUniformDepth@var[]..[]",
+      "iconName": "/src/resources/icons/IsUniformDepth.png",
+      "contextData": "IsUniformDepth@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "IsRectangular",
-      "iconName": "IsRectangular",
-      "creationName": "IsRectangular@var[]..[]",
+      "iconName": "/src/resources/icons/IsRectangular.png",
+      "contextData": "IsRectangular@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "NormalizeDepth",
-      "iconName": "NormalizeDepth.varN",
-      "creationName": "NormalizeDepth@var[]..[]",
+      "iconName": "/src/resources/icons/NormalizeDepth.varN.png",
+      "contextData": "NormalizeDepth@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "NormalizeDepth",
-      "iconName": "NormalizeDepth.varN-var",
-      "creationName": "NormalizeDepth@var[]..[],var",
+      "iconName": "/src/resources/icons/NormalizeDepth.varN-var.png",
+      "contextData": "NormalizeDepth@var[]..[],var",
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "DSCore.Math.Map",
-      "iconName": "DSCore.Math.Map",
-      "creationName": "DSCore.Math.Map@double,double,double",
+      "fullyQualifiedName": "Map",
+      "iconName": "/src/resources/icons/Map.png",
+      "contextData": "Map@double,double,double",
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "DSCore.Math.MapTo",
-      "iconName": "DSCore.Math.MapTo",
-      "creationName": "DSCore.Math.MapTo@double,double,double,double,double",
-      "itemType": "action"
-    },
-    {
-      "fullyQualifiedName": "ImportFromCSV",
-      "iconName": "ImportFromCSV.string",
-      "creationName": "ImportFromCSV@string",
+      "fullyQualifiedName": "MapTo",
+      "iconName": "/src/resources/icons/MapTo.png",
+      "contextData": "MapTo@double,double,double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "ImportFromCSV",
-      "iconName": "ImportFromCSV.string-bool",
-      "creationName": "ImportFromCSV@string,bool",
+      "iconName": "/src/resources/icons/ImportFromCSV.string.png",
+      "contextData": "ImportFromCSV@string",
+      "itemType": "action"
+    },
+    {
+      "fullyQualifiedName": "ImportFromCSV",
+      "iconName": "/src/resources/icons/ImportFromCSV.string-bool.png",
+      "contextData": "ImportFromCSV@string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "GetKeys",
-      "iconName": "GetKeys",
-      "creationName": "GetKeys@var[]..[]",
+      "iconName": "/src/resources/icons/GetKeys.png",
+      "contextData": "GetKeys@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "GetValues",
-      "iconName": "GetValues",
-      "creationName": "GetValues@var[]..[]",
+      "iconName": "/src/resources/icons/GetValues.png",
+      "contextData": "GetValues@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "RemoveKey",
-      "iconName": "RemoveKey",
-      "creationName": "RemoveKey@var[]..[],var",
+      "iconName": "/src/resources/icons/RemoveKey.png",
+      "contextData": "RemoveKey@var[]..[],var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "ContainsKey",
-      "iconName": "ContainsKey",
-      "creationName": "ContainsKey@var[]..[],var",
+      "iconName": "/src/resources/icons/ContainsKey.png",
+      "contextData": "ContainsKey@var[]..[],var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "MinimumItemByKey",
-      "iconName": "MinimumItemByKey",
-      "creationName": "MinimumItemByKey@var[]..[],Function",
+      "iconName": "/src/resources/icons/MinimumItemByKey.png",
+      "contextData": "MinimumItemByKey@var[]..[],Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "MaximumItemByKey",
-      "iconName": "MaximumItemByKey",
-      "creationName": "MaximumItemByKey@var[]..[],Function",
+      "iconName": "/src/resources/icons/MaximumItemByKey.png",
+      "contextData": "MaximumItemByKey@var[]..[],Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "SortByFunction",
-      "iconName": "SortByFunction",
-      "creationName": "SortByFunction@var[]..[],Function",
+      "iconName": "/src/resources/icons/SortByFunction.png",
+      "contextData": "SortByFunction@var[]..[],Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "GroupByFunction",
-      "iconName": "GroupByFunction",
-      "creationName": "GroupByFunction@var[]..[],Function",
+      "iconName": "/src/resources/icons/GroupByFunction.png",
+      "contextData": "GroupByFunction@var[]..[],Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "TrueForAll",
-      "iconName": "TrueForAll",
-      "creationName": "TrueForAll@var[]..[],Function",
+      "iconName": "/src/resources/icons/TrueForAll.png",
+      "contextData": "TrueForAll@var[]..[],Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "TrueForAny",
-      "iconName": "TrueForAny",
-      "creationName": "TrueForAny@var[]..[],Function",
+      "iconName": "/src/resources/icons/TrueForAny.png",
+      "contextData": "TrueForAny@var[]..[],Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "LoopWhile",
-      "iconName": "LoopWhile",
-      "creationName": "LoopWhile@var[]..[],Function,Function",
+      "iconName": "/src/resources/icons/LoopWhile.png",
+      "contextData": "LoopWhile@var[]..[],Function,Function",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "NewtonRootFind1DNoDeriv",
-      "iconName": "NewtonRootFind1DNoDeriv",
-      "creationName": "NewtonRootFind1DNoDeriv@Function,double,int",
+      "iconName": "/src/resources/icons/NewtonRootFind1DNoDeriv.png",
+      "contextData": "NewtonRootFind1DNoDeriv@Function,double,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "NewtonRootFind1DWithDeriv",
-      "iconName": "NewtonRootFind1DWithDeriv",
-      "creationName": "NewtonRootFind1DWithDeriv@Function,Function,double,int",
+      "iconName": "/src/resources/icons/NewtonRootFind1DWithDeriv.png",
+      "contextData": "NewtonRootFind1DWithDeriv@Function,Function,double,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "+",
-      "iconName": "add",
-      "creationName": "+@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/add.png",
+      "contextData": "+@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "-",
-      "iconName": "sub",
-      "creationName": "-@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/sub.png",
+      "contextData": "-@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "*",
-      "iconName": "mul",
-      "creationName": "*@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/mul.png",
+      "contextData": "*@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "/",
-      "iconName": "div",
-      "creationName": "/@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/div.png",
+      "contextData": "/@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "==",
-      "iconName": "eq",
-      "creationName": "==@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/eq.png",
+      "contextData": "==@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": ">=",
-      "iconName": "ge",
-      "creationName": ">=@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/ge.png",
+      "contextData": ">=@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": ">",
-      "iconName": "gt",
-      "creationName": ">@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/gt.png",
+      "contextData": ">@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "%",
-      "iconName": "mod",
-      "creationName": "%@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/mod.png",
+      "contextData": "%@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "<=",
-      "iconName": "le",
-      "creationName": "<=@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/le.png",
+      "contextData": "<=@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "<",
-      "iconName": "lt",
-      "creationName": "<@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/lt.png",
+      "contextData": "<@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "&&",
-      "iconName": "and",
-      "creationName": "&&@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/and.png",
+      "contextData": "&&@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "||",
-      "iconName": "or",
-      "creationName": "||@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/or.png",
+      "contextData": "||@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "!=",
-      "iconName": "nq",
-      "creationName": "!=@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/nq.png",
+      "contextData": "!=@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Not",
-      "iconName": "Not",
-      "creationName": "Not@var[]..[]",
+      "iconName": "/src/resources/icons/Not.png",
+      "contextData": "Not@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByThreePoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.ByThreePoints",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.ByThreePoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByThreePoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.ByThreePoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointRadiusAngle",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointRadiusAngle",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointRadiusAngle@Autodesk.DesignScript.Geometry.Point,double,double,double,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByCenterPointRadiusAngle.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointRadiusAngle@Autodesk.DesignScript.Geometry.Point,double,double,double,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointSweepAngle",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointSweepAngle",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointSweepAngle@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointSweepAngle.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointSweepAngle@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointEndPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointEndPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointEndPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByFillet",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.ByFillet",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.ByFillet@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByFillet.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.ByFillet@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByFilletTangentToCurve",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.ByFilletTangentToCurve",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.ByFilletTangentToCurve@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByFilletTangentToCurve.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.ByFilletTangentToCurve@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByBestFitThroughPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.ByBestFitThroughPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.ByBestFitThroughPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByBestFitThroughPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.ByBestFitThroughPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByStartEndAndTangencies",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.ByStartEndAndTangencies",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.ByStartEndAndTangencies@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByStartEndAndTangencies.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.ByStartEndAndTangencies@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.ByStartPointEndPointStartTangent",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.ByStartPointEndPointStartTangent",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.ByStartPointEndPointStartTangent@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.ByStartPointEndPointStartTangent.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.ByStartPointEndPointStartTangent@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.CenterPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.CenterPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.CenterPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.CenterPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.CenterPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.Radius",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.Radius",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.Radius",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.Radius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.Radius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.StartAngle",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.StartAngle",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.StartAngle",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.StartAngle.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.StartAngle",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Arc.SweepAngle",
-      "iconName": "Autodesk.DesignScript.Geometry.Arc.SweepAngle",
-      "creationName": "Autodesk.DesignScript.Geometry.Arc.SweepAngle",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Arc.SweepAngle.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Arc.SweepAngle",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ByParameterLineOnSurface",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ByParameterLineOnSurface",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ByParameterLineOnSurface@Autodesk.DesignScript.Geometry.Surface,Autodesk.DesignScript.Geometry.UV,Autodesk.DesignScript.Geometry.UV",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ByParameterLineOnSurface.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ByParameterLineOnSurface@Autodesk.DesignScript.Geometry.Surface,Autodesk.DesignScript.Geometry.UV,Autodesk.DesignScript.Geometry.UV",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ByBlendBetweenCurves",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ByBlendBetweenCurves",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ByBlendBetweenCurves@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,bool,bool,bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ByBlendBetweenCurves.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ByBlendBetweenCurves@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,bool,bool,bool",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ByIsoCurveOnSurface",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ByIsoCurveOnSurface",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ByIsoCurveOnSurface@Autodesk.DesignScript.Geometry.Surface,int,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ByIsoCurveOnSurface.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ByIsoCurveOnSurface@Autodesk.DesignScript.Geometry.Surface,int,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Length",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.Length",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.Length",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Length.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.Length",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.IsPlanar",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.IsPlanar",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.IsPlanar",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.IsPlanar.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.IsPlanar",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.IsClosed",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.IsClosed",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.IsClosed",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.IsClosed.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.IsClosed",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.StartPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.StartPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.StartPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.StartPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.StartPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.EndPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.EndPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.EndPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.EndPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.EndPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Normal",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.Normal",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.Normal",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Normal.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.Normal",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.PointAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.PointAtParameter@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.PointAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TangentAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.TangentAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.TangentAtParameter@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TangentAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.TangentAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.NormalAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.NormalAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.NormalAtParameter@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.NormalAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.NormalAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtParameter@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.HorizontalFrameAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.HorizontalFrameAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.HorizontalFrameAtParameter@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.HorizontalFrameAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.HorizontalFrameAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PlaneAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.PlaneAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.PlaneAtParameter@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PlaneAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.PlaneAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointAtSegmentLength",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.PointAtSegmentLength",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.PointAtSegmentLength@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointAtSegmentLength.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.PointAtSegmentLength@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualSegmentLength",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualSegmentLength",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualSegmentLength@int",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointsAtEqualSegmentLength.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualSegmentLength@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualChordLength",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualChordLength",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualChordLength@int",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointsAtEqualChordLength.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualChordLength@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointAtChordLength",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.PointAtChordLength",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.PointAtChordLength@double,double,bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointAtChordLength.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.PointAtChordLength@double,double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointsAtSegmentLengthFromPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.PointsAtSegmentLengthFromPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.PointsAtSegmentLengthFromPoint@Autodesk.DesignScript.Geometry.Point,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointsAtSegmentLengthFromPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.PointsAtSegmentLengthFromPoint@Autodesk.DesignScript.Geometry.Point,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PointsAtChordLengthFromPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.PointsAtChordLengthFromPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.PointsAtChordLengthFromPoint@Autodesk.DesignScript.Geometry.Point,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PointsAtChordLengthFromPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.PointsAtChordLengthFromPoint@Autodesk.DesignScript.Geometry.Point,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtSegmentLength",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtSegmentLength",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtSegmentLength@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtSegmentLength.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.CoordinateSystemAtSegmentLength@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PlaneAtSegmentLength",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.PlaneAtSegmentLength",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.PlaneAtSegmentLength@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PlaneAtSegmentLength.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.PlaneAtSegmentLength@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SegmentLengthAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.SegmentLengthAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.SegmentLengthAtParameter@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SegmentLengthAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.SegmentLengthAtParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ParameterAtSegmentLength",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ParameterAtSegmentLength",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ParameterAtSegmentLength@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ParameterAtSegmentLength.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ParameterAtSegmentLength@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ParameterAtChordLength",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ParameterAtChordLength",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ParameterAtChordLength@double,double,bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ParameterAtChordLength.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ParameterAtChordLength@double,double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.StartParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.StartParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.StartParameter",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.StartParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.StartParameter",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.EndParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.EndParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.EndParameter",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.EndParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.EndParameter",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SegmentLengthBetweenParameters",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.SegmentLengthBetweenParameters",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.SegmentLengthBetweenParameters@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SegmentLengthBetweenParameters.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.SegmentLengthBetweenParameters@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ParameterAtPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ParameterAtPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ParameterAtPoint@Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ParameterAtPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ParameterAtPoint@Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Reverse",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.Reverse",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.Reverse",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Reverse.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.Reverse",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Offset",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.Offset",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.Offset@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Offset.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.Offset@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PullOntoPlane",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.PullOntoPlane",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.PullOntoPlane@Autodesk.DesignScript.Geometry.Plane",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PullOntoPlane.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.PullOntoPlane@Autodesk.DesignScript.Geometry.Plane",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.PullOntoSurface",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.PullOntoSurface",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.PullOntoSurface@Autodesk.DesignScript.Geometry.Surface",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.PullOntoSurface.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.PullOntoSurface@Autodesk.DesignScript.Geometry.Surface",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TrimByStartParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.TrimByStartParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.TrimByStartParameter@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimByStartParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.TrimByStartParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TrimByEndParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.TrimByEndParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.TrimByEndParameter@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimByEndParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.TrimByEndParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TrimByParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.TrimByParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.TrimByParameter@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimByParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.TrimByParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TrimInteriorByParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.TrimInteriorByParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.TrimInteriorByParameter@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimInteriorByParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.TrimInteriorByParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter.double1",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter@double[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter.double1.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter@double[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter.double1-bool",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter@double[],bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter.double1-bool.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.TrimSegmentsByParameter@double[],bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SplitByParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.SplitByParameter.double",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.SplitByParameter@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SplitByParameter.double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.SplitByParameter@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SplitByParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.SplitByParameter.double1",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.SplitByParameter@double[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SplitByParameter.double1.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.SplitByParameter@double[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SplitByPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.SplitByPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.SplitByPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SplitByPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.SplitByPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Join",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.Join",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.Join@Autodesk.DesignScript.Geometry.Curve[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Join.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.Join@Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Extrude",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.Extrude.double",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.Extrude@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Extrude.double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.Extrude@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Extrude",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.Extrude.Vector",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.Extrude@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Extrude.Vector.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.Extrude@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Extrude",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.Extrude.Vector-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.Extrude@Autodesk.DesignScript.Geometry.Vector,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Extrude.Vector-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.Extrude@Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid.double",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid.double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid.Vector",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid.Vector.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid.Vector-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid@Autodesk.DesignScript.Geometry.Vector,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid.Vector-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ExtrudeAsSolid@Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Extend",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.Extend",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.Extend@double,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Extend.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.Extend@double,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ExtendStart",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ExtendStart",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ExtendStart@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtendStart.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ExtendStart@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ExtendEnd",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ExtendEnd",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ExtendEnd@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ExtendEnd.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ExtendEnd@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ApproximateWithArcAndLineSegments",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ApproximateWithArcAndLineSegments",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ApproximateWithArcAndLineSegments",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ApproximateWithArcAndLineSegments.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ApproximateWithArcAndLineSegments",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.ToNurbsCurve",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.ToNurbsCurve",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.ToNurbsCurve",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.ToNurbsCurve.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.ToNurbsCurve",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Patch",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.Patch",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.Patch",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Patch.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.Patch",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Project",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.Project",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.Project@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Project.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.Project@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SweepAsSurface",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.SweepAsSurface",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.SweepAsSurface@Autodesk.DesignScript.Geometry.Curve",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SweepAsSurface.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.SweepAsSurface@Autodesk.DesignScript.Geometry.Curve",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.SweepAsSolid",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.SweepAsSolid",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.SweepAsSolid@Autodesk.DesignScript.Geometry.Curve",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.SweepAsSolid.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.SweepAsSolid@Autodesk.DesignScript.Geometry.Curve",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Curve.Simplify",
-      "iconName": "Autodesk.DesignScript.Geometry.Curve.Simplify",
-      "creationName": "Autodesk.DesignScript.Geometry.Curve.Simplify@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Curve.Simplify.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Curve.Simplify@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Translate",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Translate.double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Translate@double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Translate.double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Translate@double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Translate",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Translate.Vector",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Translate@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Translate.Vector.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Translate@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Translate",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Translate.Vector-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Translate@Autodesk.DesignScript.Geometry.Vector,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Translate.Vector-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Translate@Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Transform",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Transform.CoordinateSystem",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Transform.CoordinateSystem.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Transform",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Transform.CoordinateSystem-CoordinateSystem",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem,Autodesk.DesignScript.Geometry.CoordinateSystem",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Transform.CoordinateSystem-CoordinateSystem.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem,Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Rotate",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Rotate.Point-Vector-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Rotate@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Rotate.Point-Vector-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Rotate@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Rotate",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Rotate.Plane-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Rotate@Autodesk.DesignScript.Geometry.Plane,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Rotate.Plane-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Rotate@Autodesk.DesignScript.Geometry.Plane,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Mirror",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Mirror",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Mirror@Autodesk.DesignScript.Geometry.Plane",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Mirror.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Mirror@Autodesk.DesignScript.Geometry.Plane",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Scale",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Scale.double",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Scale@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale.double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Scale@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Scale",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Scale.double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Scale@double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale.double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Scale@double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Scale",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Scale.Plane-double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Scale@Autodesk.DesignScript.Geometry.Plane,double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale.Plane-double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Scale@Autodesk.DesignScript.Geometry.Plane,double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Scale",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Scale.Point-Point-Point",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Scale@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale.Point-Point-Point.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Scale@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Scale1D",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Scale1D",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Scale1D@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale1D.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Scale1D@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Scale2D",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Scale2D",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Scale2D@Autodesk.DesignScript.Geometry.Plane,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Scale2D.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Scale2D@Autodesk.DesignScript.Geometry.Plane,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.DistanceTo",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.DistanceTo",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.DistanceTo@Autodesk.DesignScript.Geometry.Geometry",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.DistanceTo.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.DistanceTo@Autodesk.DesignScript.Geometry.Geometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.ClosestPointTo",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.ClosestPointTo",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.ClosestPointTo@Autodesk.DesignScript.Geometry.Geometry",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ClosestPointTo.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.ClosestPointTo@Autodesk.DesignScript.Geometry.Geometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.DoesIntersect",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.DoesIntersect",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.DoesIntersect@Autodesk.DesignScript.Geometry.Geometry",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.DoesIntersect.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.DoesIntersect@Autodesk.DesignScript.Geometry.Geometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Intersect",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Intersect",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Intersect@Autodesk.DesignScript.Geometry.Geometry",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Intersect.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Intersect@Autodesk.DesignScript.Geometry.Geometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.IntersectAll",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.IntersectAll",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.IntersectAll@Autodesk.DesignScript.Geometry.Geometry[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.IntersectAll.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.IntersectAll@Autodesk.DesignScript.Geometry.Geometry[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Split",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Split",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Split@Autodesk.DesignScript.Geometry.Geometry",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Split.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Split@Autodesk.DesignScript.Geometry.Geometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Trim",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Trim",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Trim@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Trim.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Trim@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.Explode",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.Explode",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.Explode",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.Explode.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.Explode",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.IsAlmostEqualTo",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.IsAlmostEqualTo",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.IsAlmostEqualTo@Autodesk.DesignScript.Geometry.Geometry",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.IsAlmostEqualTo.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.IsAlmostEqualTo@Autodesk.DesignScript.Geometry.Geometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.BoundingBox",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.BoundingBox",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.BoundingBox",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.BoundingBox.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.BoundingBox",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT.var",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT@var",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT.var.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT.string",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT@string",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT.string.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.ImportFromSAT@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.ExportToSAT",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.ExportToSAT.Geometry1-string",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.ExportToSAT@Autodesk.DesignScript.Geometry.Geometry[],string",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ExportToSAT.Geometry1-string.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.ExportToSAT@Autodesk.DesignScript.Geometry.Geometry[],string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB.",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB..png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB.Geometry1",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB@Autodesk.DesignScript.Geometry.Geometry[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB.Geometry1.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.SerializeAsSAB@Autodesk.DesignScript.Geometry.Geometry[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.DeserializeFromSAB",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.DeserializeFromSAB",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.DeserializeFromSAB@int[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.DeserializeFromSAB.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.DeserializeFromSAB@int[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Geometry.ContextCoordinateSystem",
-      "iconName": "Autodesk.DesignScript.Geometry.Geometry.ContextCoordinateSystem",
-      "creationName": "Autodesk.DesignScript.Geometry.Geometry.ContextCoordinateSystem",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.ContextCoordinateSystem.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Geometry.ContextCoordinateSystem",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.ByGeometry",
-      "iconName": "Autodesk.DesignScript.Geometry.BoundingBox.ByGeometry",
-      "creationName": "Autodesk.DesignScript.Geometry.BoundingBox.ByGeometry@Autodesk.DesignScript.Geometry.Geometry[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.ByGeometry.png",
+      "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.ByGeometry@Autodesk.DesignScript.Geometry.Geometry[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.ByCorners",
-      "iconName": "Autodesk.DesignScript.Geometry.BoundingBox.ByCorners",
-      "creationName": "Autodesk.DesignScript.Geometry.BoundingBox.ByCorners@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.ByCorners.png",
+      "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.ByCorners@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.MinPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.BoundingBox.MinPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.BoundingBox.MinPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.MinPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.MinPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.MaxPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.BoundingBox.MaxPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.BoundingBox.MaxPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.MaxPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.MaxPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.Intersection",
-      "iconName": "Autodesk.DesignScript.Geometry.BoundingBox.Intersection",
-      "creationName": "Autodesk.DesignScript.Geometry.BoundingBox.Intersection@Autodesk.DesignScript.Geometry.BoundingBox",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.Intersection.png",
+      "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.Intersection@Autodesk.DesignScript.Geometry.BoundingBox",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.Intersects",
-      "iconName": "Autodesk.DesignScript.Geometry.BoundingBox.Intersects",
-      "creationName": "Autodesk.DesignScript.Geometry.BoundingBox.Intersects@Autodesk.DesignScript.Geometry.BoundingBox",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.Intersects.png",
+      "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.Intersects@Autodesk.DesignScript.Geometry.BoundingBox",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.IsEmpty",
-      "iconName": "Autodesk.DesignScript.Geometry.BoundingBox.IsEmpty",
-      "creationName": "Autodesk.DesignScript.Geometry.BoundingBox.IsEmpty",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.IsEmpty.png",
+      "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.IsEmpty",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.Contains",
-      "iconName": "Autodesk.DesignScript.Geometry.BoundingBox.Contains",
-      "creationName": "Autodesk.DesignScript.Geometry.BoundingBox.Contains@Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.Contains.png",
+      "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.Contains@Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.ToCuboid",
-      "iconName": "Autodesk.DesignScript.Geometry.BoundingBox.ToCuboid",
-      "creationName": "Autodesk.DesignScript.Geometry.BoundingBox.ToCuboid",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.ToCuboid.png",
+      "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.ToCuboid",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.BoundingBox.ToPolySurface",
-      "iconName": "Autodesk.DesignScript.Geometry.BoundingBox.ToPolySurface",
-      "creationName": "Autodesk.DesignScript.Geometry.BoundingBox.ToPolySurface",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.ToPolySurface.png",
+      "contextData": "Autodesk.DesignScript.Geometry.BoundingBox.ToPolySurface",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Identity",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Identity",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Identity",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Identity.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Identity",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByMatrix",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByMatrix",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByMatrix@double[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByMatrix.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByMatrix@double[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin.double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin.double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin.double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin.double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin.Point",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin.Point.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByPlane",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByPlane",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByPlane@Autodesk.DesignScript.Geometry.Plane",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByPlane.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByPlane@Autodesk.DesignScript.Geometry.Plane",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors.Point-Vector-Vector",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors.Point-Vector-Vector.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors.Point-Vector-Vector-Vector",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors.Point-Vector-Vector-Vector.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOriginVectors@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByCylindricalCoordinates",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByCylindricalCoordinates",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByCylindricalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ByCylindricalCoordinates.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByCylindricalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.BySphericalCoordinates",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.BySphericalCoordinates",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.BySphericalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.BySphericalCoordinates.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.BySphericalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsSingular",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsSingular",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsSingular",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.IsSingular.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsSingular",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsScaledOrtho",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsScaledOrtho",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsScaledOrtho",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.IsScaledOrtho.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsScaledOrtho",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsUniscaledOrtho",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsUniscaledOrtho",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsUniscaledOrtho",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.IsUniscaledOrtho.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsUniscaledOrtho",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Determinant",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Determinant",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Determinant",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Determinant.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Determinant",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Origin",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Origin",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Origin",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Origin.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Origin",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.XAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.XAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.XAxis",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.XAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.XAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.YAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.YAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.YAxis",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.YAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.YAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZAxis",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ZAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.XScaleFactor",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.XScaleFactor",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.XScaleFactor",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.XScaleFactor.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.XScaleFactor",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.YScaleFactor",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.YScaleFactor",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.YScaleFactor",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.YScaleFactor.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.YScaleFactor",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZScaleFactor",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZScaleFactor",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZScaleFactor",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ZScaleFactor.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZScaleFactor",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.XYPlane",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.XYPlane",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.XYPlane",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.XYPlane.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.XYPlane",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.YZPlane",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.YZPlane",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.YZPlane",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.YZPlane.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.YZPlane",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZXPlane",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZXPlane",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZXPlane",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ZXPlane.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ZXPlane",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Inverse",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Inverse",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Inverse",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Inverse.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Inverse",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Mirror",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Mirror",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Mirror@Autodesk.DesignScript.Geometry.Plane",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Mirror.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Mirror@Autodesk.DesignScript.Geometry.Plane",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.PostMultiplyBy",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.PostMultiplyBy",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.PostMultiplyBy@Autodesk.DesignScript.Geometry.CoordinateSystem",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.PostMultiplyBy.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.PostMultiplyBy@Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.PreMultiplyBy",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.PreMultiplyBy",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.PreMultiplyBy@Autodesk.DesignScript.Geometry.CoordinateSystem",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.PreMultiplyBy.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.PreMultiplyBy@Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ScaleFactor",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ScaleFactor",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.ScaleFactor",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.ScaleFactor.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.ScaleFactor",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsEqualTo",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsEqualTo",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsEqualTo@Autodesk.DesignScript.Geometry.CoordinateSystem",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.IsEqualTo.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.IsEqualTo@Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate.double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate@double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Translate.double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate@double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate.Vector",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Translate.Vector.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate.Vector-double",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate@Autodesk.DesignScript.Geometry.Vector,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Translate.Vector-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Translate@Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Transform",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Transform.CoordinateSystem",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Transform.CoordinateSystem.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Transform",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Transform.CoordinateSystem-CoordinateSystem",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem,Autodesk.DesignScript.Geometry.CoordinateSystem",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Transform.CoordinateSystem-CoordinateSystem.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem,Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate.Point-Vector-double",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate.Point-Vector-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate.Plane-double",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate@Autodesk.DesignScript.Geometry.Plane,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate.Plane-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Rotate@Autodesk.DesignScript.Geometry.Plane,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.double",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale@double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale@double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.Plane-double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale@Autodesk.DesignScript.Geometry.Plane,double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.Plane-double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale@Autodesk.DesignScript.Geometry.Plane,double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.Point-Point-Point",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale.Point-Point-Point.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale1D",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale1D",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale1D@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale1D.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale1D@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale2D",
-      "iconName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale2D",
-      "creationName": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale2D@Autodesk.DesignScript.Geometry.Plane,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.CoordinateSystem.Scale2D.png",
+      "contextData": "Autodesk.DesignScript.Geometry.CoordinateSystem.Scale2D@Autodesk.DesignScript.Geometry.Plane,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates.double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates@double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.ByCoordinates.double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates@double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates.double-double-double-bool",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates@double,double,double,bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.ByCoordinates.double-double-double-bool.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates@double,double,double,bool",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.ByTwoPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.ByTwoPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.ByTwoPoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.ByTwoPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.ByTwoPoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.XAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.XAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.XAxis",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.XAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.XAxis",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.YAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.YAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.YAxis",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.YAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.YAxis",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.ZAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.ZAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.ZAxis",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.ZAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.ZAxis",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.X",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.X",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.X",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.X.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.X",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Y",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Y",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Y",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Y.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Y",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Z",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Z",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Z",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Z.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Z",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Length",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Length",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Length",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Length.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Length",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.AsPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.AsPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.AsPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.AsPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.AsPoint",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Reverse",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Reverse",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Reverse",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Reverse.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Reverse",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Add",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Add",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Add@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Add.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Add@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Subtract",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Subtract",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Subtract@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Subtract.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Subtract@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Cross",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Cross",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Cross@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Cross.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Cross@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Dot",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Dot",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Dot@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Dot.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Dot@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Normalized",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Normalized",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Normalized",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Normalized.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Normalized",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.IsParallel",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.IsParallel",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.IsParallel@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.IsParallel.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.IsParallel@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.IsAlmostEqualTo",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.IsAlmostEqualTo",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.IsAlmostEqualTo@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.IsAlmostEqualTo.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.IsAlmostEqualTo@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Transform",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Transform",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Transform.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Rotate",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Rotate.Vector-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Rotate@Autodesk.DesignScript.Geometry.Vector,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Rotate.Vector-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Rotate@Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Rotate",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Rotate.Plane-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Rotate@Autodesk.DesignScript.Geometry.Plane,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Rotate.Plane-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Rotate@Autodesk.DesignScript.Geometry.Plane,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Scale",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Scale.double",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Scale@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Scale.double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Scale@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.Scale",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.Scale.double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.Scale@double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.Scale.double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.Scale@double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.AngleWithVector",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.AngleWithVector",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.AngleWithVector@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.AngleWithVector.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.AngleWithVector@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vector.AngleAboutAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.Vector.AngleAboutAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.Vector.AngleAboutAxis@Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vector.AngleAboutAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vector.AngleAboutAxis@Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.ByCoordinates",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.ByCoordinates.double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.ByCoordinates.double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.ByCoordinates",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.ByCoordinates.double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.ByCoordinates.double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.Origin",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.Origin",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.Origin",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Origin.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.Origin",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.ByCartesianCoordinates",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.ByCartesianCoordinates",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.ByCartesianCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.ByCartesianCoordinates.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.ByCartesianCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.ByCylindricalCoordinates",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.ByCylindricalCoordinates",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.ByCylindricalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.ByCylindricalCoordinates.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.ByCylindricalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.BySphericalCoordinates",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.BySphericalCoordinates",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.BySphericalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.BySphericalCoordinates.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.BySphericalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.PruneDuplicates",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.PruneDuplicates",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.PruneDuplicates@Autodesk.DesignScript.Geometry.Point[],double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.PruneDuplicates.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.PruneDuplicates@Autodesk.DesignScript.Geometry.Point[],double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.X",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.X",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.X",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.X.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.X",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.Y",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.Y",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.Y",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Y.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.Y",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.Z",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.Z",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.Z",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Z.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.Z",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.AsVector",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.AsVector",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.AsVector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.AsVector.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.AsVector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.Add",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.Add",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Add.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.Subtract",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.Subtract",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.Subtract@Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Subtract.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.Subtract@Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Point.Project",
-      "iconName": "Autodesk.DesignScript.Geometry.Point.Project",
-      "creationName": "Autodesk.DesignScript.Geometry.Point.Project@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Point.Project.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Point.Project@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ByOriginNormal",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.ByOriginNormal",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.ByOriginNormal@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByOriginNormal.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.ByOriginNormal@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ByOriginNormalXAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.ByOriginNormalXAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.ByOriginNormalXAxis@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByOriginNormalXAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.ByOriginNormalXAxis@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ByOriginXAxisYAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.ByOriginXAxisYAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.ByOriginXAxisYAxis@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByOriginXAxisYAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.ByOriginXAxisYAxis@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ByBestFitThroughPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.ByBestFitThroughPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.ByBestFitThroughPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByBestFitThroughPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.ByBestFitThroughPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ByLineAndPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.ByLineAndPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.ByLineAndPoint@Autodesk.DesignScript.Geometry.Line,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByLineAndPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.ByLineAndPoint@Autodesk.DesignScript.Geometry.Line,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ByThreePoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.ByThreePoints",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.ByThreePoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ByThreePoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.ByThreePoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.XY",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.XY",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.XY",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.XY.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.XY",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.XZ",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.XZ",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.XZ",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.XZ.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.XZ",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.YZ",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.YZ",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.YZ",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.YZ.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.YZ",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.Origin",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.Origin",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.Origin",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.Origin.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.Origin",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.Normal",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.Normal",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.Normal",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.Normal.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.Normal",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.XAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.XAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.XAxis",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.XAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.XAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.YAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.YAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.YAxis",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.YAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.YAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.ToCoordinateSystem",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.ToCoordinateSystem",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.ToCoordinateSystem",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.ToCoordinateSystem.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.ToCoordinateSystem",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Plane.Offset",
-      "iconName": "Autodesk.DesignScript.Geometry.Plane.Offset",
-      "creationName": "Autodesk.DesignScript.Geometry.Plane.Offset@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Plane.Offset.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Plane.Offset@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ByLoft",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.ByLoft.Curve1",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByLoft.Curve1.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ByLoft",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.ByLoft.Curve1-Curve1",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[],Autodesk.DesignScript.Geometry.Curve[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByLoft.Curve1-Curve1.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[],Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ByRuledLoft",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.ByRuledLoft",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.ByRuledLoft@Autodesk.DesignScript.Geometry.Line[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByRuledLoft.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.ByRuledLoft@Autodesk.DesignScript.Geometry.Line[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.BySweep",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.BySweep",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.BySweep@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.BySweep.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.BySweep@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ByPerimeterPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.ByPerimeterPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.ByPerimeterPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByPerimeterPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.ByPerimeterPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.BySweep2Rails",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.BySweep2Rails",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.BySweep2Rails@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.BySweep2Rails.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.BySweep2Rails@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ByRevolve",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.ByRevolve",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.ByRevolve@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByRevolve.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.ByRevolve@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ByPatch",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.ByPatch",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.ByPatch@Autodesk.DesignScript.Geometry.Curve",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ByPatch.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.ByPatch@Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Area",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.Area",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.Area",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Area.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.Area",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Perimeter",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.Perimeter",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.Perimeter",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Perimeter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.Perimeter",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ClosedInU",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.ClosedInU",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.ClosedInU",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ClosedInU.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.ClosedInU",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ClosedInV",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.ClosedInV",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.ClosedInV",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ClosedInV.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.ClosedInV",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Closed",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.Closed",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.Closed",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Closed.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.Closed",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.SubtractFrom",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.SubtractFrom",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.SubtractFrom@Autodesk.DesignScript.Geometry.Solid",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.SubtractFrom.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.SubtractFrom@Autodesk.DesignScript.Geometry.Solid",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.UVParameterAtPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.UVParameterAtPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.UVParameterAtPoint@Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.UVParameterAtPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.UVParameterAtPoint@Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.TrimWithEdgeLoops",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.TrimWithEdgeLoops",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.TrimWithEdgeLoops@Autodesk.DesignScript.Geometry.PolyCurve[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.TrimWithEdgeLoops.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.TrimWithEdgeLoops@Autodesk.DesignScript.Geometry.PolyCurve[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.NormalAtPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.NormalAtPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.NormalAtPoint@Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.NormalAtPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.NormalAtPoint@Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ToNurbsSurface",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.ToNurbsSurface",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.ToNurbsSurface",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ToNurbsSurface.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.ToNurbsSurface",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ApproximateWithTolerance",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.ApproximateWithTolerance",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.ApproximateWithTolerance@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ApproximateWithTolerance.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.ApproximateWithTolerance@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Thicken",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.Thicken.double",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.Thicken@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Thicken.double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.Thicken@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Thicken",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.Thicken.double-bool",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.Thicken@double,bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Thicken.double-bool.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.Thicken@double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Offset",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.Offset",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.Offset@double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Offset.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.Offset@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.CurvatureAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.CurvatureAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.CurvatureAtParameter@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.CurvatureAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.CurvatureAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.CoordinateSystemAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.CoordinateSystemAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.CoordinateSystemAtParameter@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.CoordinateSystemAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.CoordinateSystemAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.TangentAtUParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.TangentAtUParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.TangentAtUParameter@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.TangentAtUParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.TangentAtUParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.NormalAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.NormalAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.NormalAtParameter@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.NormalAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.NormalAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.DerivativesAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.DerivativesAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.DerivativesAtParameter@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.DerivativesAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.DerivativesAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.GaussianCurvatureAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.GaussianCurvatureAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.GaussianCurvatureAtParameter@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.GaussianCurvatureAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.GaussianCurvatureAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.PrincipalCurvaturesAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.PrincipalCurvaturesAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.PrincipalCurvaturesAtParameter@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.PrincipalCurvaturesAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.PrincipalCurvaturesAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.PrincipalDirectionsAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.PrincipalDirectionsAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.PrincipalDirectionsAtParameter@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.PrincipalDirectionsAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.PrincipalDirectionsAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.PointAtParameter",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.PointAtParameter",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.PointAtParameter@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.PointAtParameter.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.PointAtParameter@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.PerimeterCurves",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.PerimeterCurves",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.PerimeterCurves",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.PerimeterCurves.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.PerimeterCurves",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.GetIsoline",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.GetIsoline",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.GetIsoline@int,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.GetIsoline.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.GetIsoline@int,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.FlipNormalDirection",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.FlipNormalDirection",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.FlipNormalDirection",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.FlipNormalDirection.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.FlipNormalDirection",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.Join",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.Join",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.Join@Autodesk.DesignScript.Geometry.Surface[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.Join.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.Join@Autodesk.DesignScript.Geometry.Surface[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Surface.ProjectInputOnto",
-      "iconName": "Autodesk.DesignScript.Geometry.Surface.ProjectInputOnto",
-      "creationName": "Autodesk.DesignScript.Geometry.Surface.ProjectInputOnto@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Surface.ProjectInputOnto.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Surface.ProjectInputOnto@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.UV.ByCoordinates",
-      "iconName": "Autodesk.DesignScript.Geometry.UV.ByCoordinates",
-      "creationName": "Autodesk.DesignScript.Geometry.UV.ByCoordinates@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.UV.ByCoordinates.png",
+      "contextData": "Autodesk.DesignScript.Geometry.UV.ByCoordinates@double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.UV.U",
-      "iconName": "Autodesk.DesignScript.Geometry.UV.U",
-      "creationName": "Autodesk.DesignScript.Geometry.UV.U",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.UV.U.png",
+      "contextData": "Autodesk.DesignScript.Geometry.UV.U",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.UV.V",
-      "iconName": "Autodesk.DesignScript.Geometry.UV.V",
-      "creationName": "Autodesk.DesignScript.Geometry.UV.V",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.UV.V.png",
+      "contextData": "Autodesk.DesignScript.Geometry.UV.V",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.ByJoinedCurves",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.ByJoinedCurves",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.ByJoinedCurves@Autodesk.DesignScript.Geometry.Curve[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ByJoinedCurves.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.ByJoinedCurves@Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.ByPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.ByPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ByPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],bool",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.ByThickeningCurve",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.ByThickeningCurve",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.ByThickeningCurve@Autodesk.DesignScript.Geometry.Curve,double,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ByThickeningCurve.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.ByThickeningCurve@Autodesk.DesignScript.Geometry.Curve,double,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.NumberOfCurves",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.NumberOfCurves",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.NumberOfCurves",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.NumberOfCurves.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.NumberOfCurves",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.Curves",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.Curves",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.Curves",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.Curves.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.Curves",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.CurveAtIndex",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.CurveAtIndex",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.CurveAtIndex@int,bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.CurveAtIndex.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.CurveAtIndex@int,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.BasePlane",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.BasePlane",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.BasePlane",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.BasePlane.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.BasePlane",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithEllipse",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithEllipse",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithEllipse@double,double,double,double,bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithEllipse.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithEllipse@double,double,double,double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithArc",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithArc",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithArc@double,double,bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithArc.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.ExtendWithArc@double,double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLine",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLine",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLine",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLine.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLine",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLineAndTangentArcs",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLineAndTangentArcs",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLineAndTangentArcs@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLineAndTangentArcs.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.CloseWithLineAndTangentArcs@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.Offset",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.Offset",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.Offset@double,bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.Offset.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.Offset@double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolyCurve.Fillet",
-      "iconName": "Autodesk.DesignScript.Geometry.PolyCurve.Fillet",
-      "creationName": "Autodesk.DesignScript.Geometry.PolyCurve.Fillet@double,bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolyCurve.Fillet.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolyCurve.Fillet@double,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ByJoinedSurfaces",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.ByJoinedSurfaces",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.ByJoinedSurfaces@Autodesk.DesignScript.Geometry.Surface[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByJoinedSurfaces.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.ByJoinedSurfaces@Autodesk.DesignScript.Geometry.Surface[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ByLoft",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.ByLoft.Curve1",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.ByLoft@Autodesk.DesignScript.Geometry.Curve[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByLoft.Curve1.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.ByLoft@Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ByLoft",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.ByLoft.Curve1-Curve1",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.ByLoft@Autodesk.DesignScript.Geometry.Curve[],Autodesk.DesignScript.Geometry.Curve[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByLoft.Curve1-Curve1.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.ByLoft@Autodesk.DesignScript.Geometry.Curve[],Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.BySweep",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.BySweep",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.BySweep@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.BySweep.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.BySweep@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.BySweep2Rails",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.BySweep2Rails",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.BySweep2Rails@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.BySweep2Rails.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.BySweep2Rails@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ByRevolve",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.ByRevolve",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.ByRevolve@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByRevolve.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.ByRevolve@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ByUnion",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.ByUnion",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.ByUnion@Autodesk.DesignScript.Geometry.Solid[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ByUnion.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.ByUnion@Autodesk.DesignScript.Geometry.Solid[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Area",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.Area",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.Area",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Area.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.Area",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Volume",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.Volume",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.Volume",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Volume.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.Volume",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Centroid",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.Centroid",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.Centroid",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Centroid.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.Centroid",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Union",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.Union",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.Union@Autodesk.DesignScript.Geometry.Solid",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Union.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.Union@Autodesk.DesignScript.Geometry.Solid",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Difference",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.Difference",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.Difference@Autodesk.DesignScript.Geometry.Solid",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Difference.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.Difference@Autodesk.DesignScript.Geometry.Solid",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.DifferenceAll",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.DifferenceAll",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.DifferenceAll@Autodesk.DesignScript.Geometry.Solid[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.DifferenceAll.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.DifferenceAll@Autodesk.DesignScript.Geometry.Solid[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ThinShell",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.ThinShell",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.ThinShell@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ThinShell.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.ThinShell@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.ProjectInputOnto",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.ProjectInputOnto",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.ProjectInputOnto@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.ProjectInputOnto.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.ProjectInputOnto@Autodesk.DesignScript.Geometry.Geometry,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Fillet",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.Fillet",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.Fillet@Autodesk.DesignScript.Geometry.Edge[],double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Fillet.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.Fillet@Autodesk.DesignScript.Geometry.Edge[],double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Solid.Chamfer",
-      "iconName": "Autodesk.DesignScript.Geometry.Solid.Chamfer",
-      "creationName": "Autodesk.DesignScript.Geometry.Solid.Chamfer@Autodesk.DesignScript.Geometry.Edge[],double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Solid.Chamfer.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Solid.Chamfer@Autodesk.DesignScript.Geometry.Edge[],double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints.Point1",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints.Point1.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints.Point1-int",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints@Autodesk.DesignScript.Geometry.Point[],int",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints.Point1-int.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints@Autodesk.DesignScript.Geometry.Point[],int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints.Point1-int-bool",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints@Autodesk.DesignScript.Geometry.Point[],int,bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints.Point1-int-bool.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints@Autodesk.DesignScript.Geometry.Point[],int,bool",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPointsWeightsKnots",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPointsWeightsKnots",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPointsWeightsKnots@Autodesk.DesignScript.Geometry.Point[],double[],double[],int",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPointsWeightsKnots.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPointsWeightsKnots@Autodesk.DesignScript.Geometry.Point[],double[],double[],int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints.Point1",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints.Point1.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints.Point1-bool",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],bool",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints.Point1-bool.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],bool",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints.Point1-int",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],int",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints.Point1-int.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPointsTangents",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPointsTangents",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPointsTangents@Autodesk.DesignScript.Geometry.Point[],Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ByPointsTangents.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ByPointsTangents@Autodesk.DesignScript.Geometry.Point[],Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.Degree",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.Degree",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.Degree",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.Degree.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.Degree",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.IsPeriodic",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.IsPeriodic",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.IsPeriodic",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.IsPeriodic.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.IsPeriodic",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.IsRational",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.IsRational",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.IsRational",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.IsRational.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.IsRational",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.ControlPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.ControlPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.ControlPoints",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.ControlPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.ControlPoints",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.Knots",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.Knots",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.Knots",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.Knots.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.Knots",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsCurve.Weights",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsCurve.Weights",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsCurve.Weights",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsCurve.Weights.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsCurve.Weights",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths",
-      "iconName": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths.double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths@double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.ByLengths.double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths@double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths",
-      "iconName": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths.Point-double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths@Autodesk.DesignScript.Geometry.Point,double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.ByLengths.Point-double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths@Autodesk.DesignScript.Geometry.Point,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths",
-      "iconName": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths.CoordinateSystem-double-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.ByLengths.CoordinateSystem-double-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.ByCorners",
-      "iconName": "Autodesk.DesignScript.Geometry.Cuboid.ByCorners",
-      "creationName": "Autodesk.DesignScript.Geometry.Cuboid.ByCorners@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.ByCorners.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cuboid.ByCorners@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.Length",
-      "iconName": "Autodesk.DesignScript.Geometry.Cuboid.Length",
-      "creationName": "Autodesk.DesignScript.Geometry.Cuboid.Length",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.Length.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cuboid.Length",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.Width",
-      "iconName": "Autodesk.DesignScript.Geometry.Cuboid.Width",
-      "creationName": "Autodesk.DesignScript.Geometry.Cuboid.Width",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.Width.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cuboid.Width",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cuboid.Height",
-      "iconName": "Autodesk.DesignScript.Geometry.Cuboid.Height",
-      "creationName": "Autodesk.DesignScript.Geometry.Cuboid.Height",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cuboid.Height.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cuboid.Height",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.ByLoft",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.ByLoft.Curve1",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ByLoft.Curve1.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.ByLoft",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.ByLoft.Curve1-Curve",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.ByLoft@Autodesk.DesignScript.Geometry.Curve[],Autodesk.DesignScript.Geometry.Curve",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ByLoft.Curve1-Curve.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.ByLoft@Autodesk.DesignScript.Geometry.Curve[],Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.ByLoftGuides",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.ByLoftGuides",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.ByLoftGuides@Autodesk.DesignScript.Geometry.Curve[],Autodesk.DesignScript.Geometry.Curve[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ByLoftGuides.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.ByLoftGuides@Autodesk.DesignScript.Geometry.Curve[],Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.ByJoinedSurfaces",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.ByJoinedSurfaces",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.ByJoinedSurfaces@Autodesk.DesignScript.Geometry.Surface[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ByJoinedSurfaces.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.ByJoinedSurfaces@Autodesk.DesignScript.Geometry.Surface[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.BySolid",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.BySolid",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.BySolid@Autodesk.DesignScript.Geometry.Solid",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.BySolid.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.BySolid@Autodesk.DesignScript.Geometry.Solid",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.BySweep",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.BySweep.Curve-Curve1",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.BySweep@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.BySweep.Curve-Curve1.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.BySweep@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.BySweep",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.BySweep.Curve-Curve",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.BySweep@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.BySweep.Curve-Curve.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.BySweep@Autodesk.DesignScript.Geometry.Curve,Autodesk.DesignScript.Geometry.Curve",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.Surfaces",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.Surfaces",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.Surfaces",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.Surfaces.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.Surfaces",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByLine",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByLine",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByLine@Autodesk.DesignScript.Geometry.Line",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByLine.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.LocateSurfacesByLine@Autodesk.DesignScript.Geometry.Line",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.UnconnectedBoundaries",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.UnconnectedBoundaries",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.UnconnectedBoundaries",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.UnconnectedBoundaries.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.UnconnectedBoundaries",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.ExtractSolids",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.ExtractSolids",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.ExtractSolids",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.ExtractSolids.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.ExtractSolids",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.SurfaceCount",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.SurfaceCount",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.SurfaceCount",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.SurfaceCount.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.SurfaceCount",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.EdgeCount",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.EdgeCount",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.EdgeCount",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.EdgeCount.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.EdgeCount",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.VertexCount",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.VertexCount",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.VertexCount",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.VertexCount.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.VertexCount",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.Fillet",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.Fillet",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.Fillet@Autodesk.DesignScript.Geometry.Edge[],double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.Fillet.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.Fillet@Autodesk.DesignScript.Geometry.Edge[],double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.PolySurface.Chamfer",
-      "iconName": "Autodesk.DesignScript.Geometry.PolySurface.Chamfer",
-      "creationName": "Autodesk.DesignScript.Geometry.PolySurface.Chamfer@Autodesk.DesignScript.Geometry.Edge[],double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.PolySurface.Chamfer.png",
+      "contextData": "Autodesk.DesignScript.Geometry.PolySurface.Chamfer@Autodesk.DesignScript.Geometry.Edge[],double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius",
-      "iconName": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius",
-      "creationName": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadiusNormal",
-      "iconName": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadiusNormal",
-      "creationName": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadiusNormal@Autodesk.DesignScript.Geometry.Point,double,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadiusNormal.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadiusNormal@Autodesk.DesignScript.Geometry.Point,double,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.ByPlaneRadius",
-      "iconName": "Autodesk.DesignScript.Geometry.Circle.ByPlaneRadius",
-      "creationName": "Autodesk.DesignScript.Geometry.Circle.ByPlaneRadius@Autodesk.DesignScript.Geometry.Plane,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByPlaneRadius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Circle.ByPlaneRadius@Autodesk.DesignScript.Geometry.Plane,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.ByThreePoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Circle.ByThreePoints",
-      "creationName": "Autodesk.DesignScript.Geometry.Circle.ByThreePoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByThreePoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Circle.ByThreePoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.ByBestFitThroughPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Circle.ByBestFitThroughPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.Circle.ByBestFitThroughPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.ByBestFitThroughPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Circle.ByBestFitThroughPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.CenterPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Circle.CenterPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Circle.CenterPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.CenterPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Circle.CenterPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Circle.Radius",
-      "iconName": "Autodesk.DesignScript.Geometry.Circle.Radius",
-      "creationName": "Autodesk.DesignScript.Geometry.Circle.Radius",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Circle.Radius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Circle.Radius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Edge.CurveGeometry",
-      "iconName": "Autodesk.DesignScript.Geometry.Edge.CurveGeometry",
-      "creationName": "Autodesk.DesignScript.Geometry.Edge.CurveGeometry",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.CurveGeometry.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Edge.CurveGeometry",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Edge.AdjacentFaces",
-      "iconName": "Autodesk.DesignScript.Geometry.Edge.AdjacentFaces",
-      "creationName": "Autodesk.DesignScript.Geometry.Edge.AdjacentFaces",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.AdjacentFaces.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Edge.AdjacentFaces",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Edge.StartVertex",
-      "iconName": "Autodesk.DesignScript.Geometry.Edge.StartVertex",
-      "creationName": "Autodesk.DesignScript.Geometry.Edge.StartVertex",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.StartVertex.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Edge.StartVertex",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Edge.EndVertex",
-      "iconName": "Autodesk.DesignScript.Geometry.Edge.EndVertex",
-      "creationName": "Autodesk.DesignScript.Geometry.Edge.EndVertex",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Edge.EndVertex.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Edge.EndVertex",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vertex.PointGeometry",
-      "iconName": "Autodesk.DesignScript.Geometry.Vertex.PointGeometry",
-      "creationName": "Autodesk.DesignScript.Geometry.Vertex.PointGeometry",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vertex.PointGeometry.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vertex.PointGeometry",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vertex.AdjacentEdges",
-      "iconName": "Autodesk.DesignScript.Geometry.Vertex.AdjacentEdges",
-      "creationName": "Autodesk.DesignScript.Geometry.Vertex.AdjacentEdges",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vertex.AdjacentEdges.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vertex.AdjacentEdges",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Vertex.AdjacentFaces",
-      "iconName": "Autodesk.DesignScript.Geometry.Vertex.AdjacentFaces",
-      "creationName": "Autodesk.DesignScript.Geometry.Vertex.AdjacentFaces",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Vertex.AdjacentFaces.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Vertex.AdjacentFaces",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.ByPointsRadius",
-      "iconName": "Autodesk.DesignScript.Geometry.Cone.ByPointsRadius",
-      "creationName": "Autodesk.DesignScript.Geometry.Cone.ByPointsRadius@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.ByPointsRadius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cone.ByPointsRadius@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.ByPointsRadii",
-      "iconName": "Autodesk.DesignScript.Geometry.Cone.ByPointsRadii",
-      "creationName": "Autodesk.DesignScript.Geometry.Cone.ByPointsRadii@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.ByPointsRadii.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cone.ByPointsRadii@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadius",
-      "iconName": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadius",
-      "creationName": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadius@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadius@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadii",
-      "iconName": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadii",
-      "creationName": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadii@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadii.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadii@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.StartPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Cone.StartPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Cone.StartPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.StartPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cone.StartPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.EndPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Cone.EndPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Cone.EndPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.EndPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cone.EndPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.RadiusRatio",
-      "iconName": "Autodesk.DesignScript.Geometry.Cone.RadiusRatio",
-      "creationName": "Autodesk.DesignScript.Geometry.Cone.RadiusRatio",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.RadiusRatio.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cone.RadiusRatio",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.StartRadius",
-      "iconName": "Autodesk.DesignScript.Geometry.Cone.StartRadius",
-      "creationName": "Autodesk.DesignScript.Geometry.Cone.StartRadius",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.StartRadius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cone.StartRadius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.EndRadius",
-      "iconName": "Autodesk.DesignScript.Geometry.Cone.EndRadius",
-      "creationName": "Autodesk.DesignScript.Geometry.Cone.EndRadius",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.EndRadius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cone.EndRadius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cone.Height",
-      "iconName": "Autodesk.DesignScript.Geometry.Cone.Height",
-      "creationName": "Autodesk.DesignScript.Geometry.Cone.Height",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cone.Height.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cone.Height",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Topology.Vertices",
-      "iconName": "Autodesk.DesignScript.Geometry.Topology.Vertices",
-      "creationName": "Autodesk.DesignScript.Geometry.Topology.Vertices",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Topology.Vertices.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Topology.Vertices",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Topology.Edges",
-      "iconName": "Autodesk.DesignScript.Geometry.Topology.Edges",
-      "creationName": "Autodesk.DesignScript.Geometry.Topology.Edges",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Topology.Edges.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Topology.Edges",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Topology.Faces",
-      "iconName": "Autodesk.DesignScript.Geometry.Topology.Faces",
-      "creationName": "Autodesk.DesignScript.Geometry.Topology.Faces",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Topology.Faces.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Topology.Faces",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Face.Edges",
-      "iconName": "Autodesk.DesignScript.Geometry.Face.Edges",
-      "creationName": "Autodesk.DesignScript.Geometry.Face.Edges",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Face.Edges.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Face.Edges",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Face.Vertices",
-      "iconName": "Autodesk.DesignScript.Geometry.Face.Vertices",
-      "creationName": "Autodesk.DesignScript.Geometry.Face.Vertices",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Face.Vertices.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Face.Vertices",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Face.SurfaceGeometry",
-      "iconName": "Autodesk.DesignScript.Geometry.Face.SurfaceGeometry",
-      "creationName": "Autodesk.DesignScript.Geometry.Face.SurfaceGeometry",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Face.SurfaceGeometry.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Face.SurfaceGeometry",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cylinder.ByRadiusHeight",
-      "iconName": "Autodesk.DesignScript.Geometry.Cylinder.ByRadiusHeight",
-      "creationName": "Autodesk.DesignScript.Geometry.Cylinder.ByRadiusHeight@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cylinder.ByRadiusHeight.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cylinder.ByRadiusHeight@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cylinder.ByPointsRadius",
-      "iconName": "Autodesk.DesignScript.Geometry.Cylinder.ByPointsRadius",
-      "creationName": "Autodesk.DesignScript.Geometry.Cylinder.ByPointsRadius@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cylinder.ByPointsRadius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cylinder.ByPointsRadius@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Cylinder.Radius",
-      "iconName": "Autodesk.DesignScript.Geometry.Cylinder.Radius",
-      "creationName": "Autodesk.DesignScript.Geometry.Cylinder.Radius",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Cylinder.Radius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Cylinder.Radius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.ByOriginRadii",
-      "iconName": "Autodesk.DesignScript.Geometry.Ellipse.ByOriginRadii",
-      "creationName": "Autodesk.DesignScript.Geometry.Ellipse.ByOriginRadii@Autodesk.DesignScript.Geometry.Point,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.ByOriginRadii.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Ellipse.ByOriginRadii@Autodesk.DesignScript.Geometry.Point,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.ByOriginVectors",
-      "iconName": "Autodesk.DesignScript.Geometry.Ellipse.ByOriginVectors",
-      "creationName": "Autodesk.DesignScript.Geometry.Ellipse.ByOriginVectors@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.ByOriginVectors.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Ellipse.ByOriginVectors@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Vector",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.ByCoordinateSystemRadii",
-      "iconName": "Autodesk.DesignScript.Geometry.Ellipse.ByCoordinateSystemRadii",
-      "creationName": "Autodesk.DesignScript.Geometry.Ellipse.ByCoordinateSystemRadii@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.ByCoordinateSystemRadii.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Ellipse.ByCoordinateSystemRadii@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.ByPlaneRadii",
-      "iconName": "Autodesk.DesignScript.Geometry.Ellipse.ByPlaneRadii",
-      "creationName": "Autodesk.DesignScript.Geometry.Ellipse.ByPlaneRadii@Autodesk.DesignScript.Geometry.Plane,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.ByPlaneRadii.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Ellipse.ByPlaneRadii@Autodesk.DesignScript.Geometry.Plane,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.CenterPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Ellipse.CenterPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Ellipse.CenterPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.CenterPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Ellipse.CenterPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.MajorAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.Ellipse.MajorAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.Ellipse.MajorAxis",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.MajorAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Ellipse.MajorAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Ellipse.MinorAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.Ellipse.MinorAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.Ellipse.MinorAxis",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Ellipse.MinorAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Ellipse.MinorAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.ByPlaneRadiiAngles",
-      "iconName": "Autodesk.DesignScript.Geometry.EllipseArc.ByPlaneRadiiAngles",
-      "creationName": "Autodesk.DesignScript.Geometry.EllipseArc.ByPlaneRadiiAngles@Autodesk.DesignScript.Geometry.Plane,double,double,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.ByPlaneRadiiAngles.png",
+      "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.ByPlaneRadiiAngles@Autodesk.DesignScript.Geometry.Plane,double,double,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.CenterPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.EllipseArc.CenterPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.EllipseArc.CenterPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.CenterPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.CenterPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.MajorAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.EllipseArc.MajorAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.EllipseArc.MajorAxis",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.MajorAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.MajorAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.MinorAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.EllipseArc.MinorAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.EllipseArc.MinorAxis",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.MinorAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.MinorAxis",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.StartAngle",
-      "iconName": "Autodesk.DesignScript.Geometry.EllipseArc.StartAngle",
-      "creationName": "Autodesk.DesignScript.Geometry.EllipseArc.StartAngle",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.StartAngle.png",
+      "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.StartAngle",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.SweepAngle",
-      "iconName": "Autodesk.DesignScript.Geometry.EllipseArc.SweepAngle",
-      "creationName": "Autodesk.DesignScript.Geometry.EllipseArc.SweepAngle",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.SweepAngle.png",
+      "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.SweepAngle",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.EllipseArc.Plane",
-      "iconName": "Autodesk.DesignScript.Geometry.EllipseArc.Plane",
-      "creationName": "Autodesk.DesignScript.Geometry.EllipseArc.Plane",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.EllipseArc.Plane.png",
+      "contextData": "Autodesk.DesignScript.Geometry.EllipseArc.Plane",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Helix.ByAxis",
-      "iconName": "Autodesk.DesignScript.Geometry.Helix.ByAxis",
-      "creationName": "Autodesk.DesignScript.Geometry.Helix.ByAxis@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Point,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.ByAxis.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Helix.ByAxis@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,Autodesk.DesignScript.Geometry.Point,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Helix.Angle",
-      "iconName": "Autodesk.DesignScript.Geometry.Helix.Angle",
-      "creationName": "Autodesk.DesignScript.Geometry.Helix.Angle",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.Angle.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Helix.Angle",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Helix.Pitch",
-      "iconName": "Autodesk.DesignScript.Geometry.Helix.Pitch",
-      "creationName": "Autodesk.DesignScript.Geometry.Helix.Pitch",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.Pitch.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Helix.Pitch",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Helix.Radius",
-      "iconName": "Autodesk.DesignScript.Geometry.Helix.Radius",
-      "creationName": "Autodesk.DesignScript.Geometry.Helix.Radius",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.Radius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Helix.Radius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Helix.AxisDirection",
-      "iconName": "Autodesk.DesignScript.Geometry.Helix.AxisDirection",
-      "creationName": "Autodesk.DesignScript.Geometry.Helix.AxisDirection",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.AxisDirection.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Helix.AxisDirection",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Helix.AxisPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Helix.AxisPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Helix.AxisPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Helix.AxisPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Helix.AxisPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.ByIndices",
-      "iconName": "Autodesk.DesignScript.Geometry.IndexGroup.ByIndices.int-int-int-int",
-      "creationName": "Autodesk.DesignScript.Geometry.IndexGroup.ByIndices@int,int,int,int",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.ByIndices.int-int-int-int.png",
+      "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.ByIndices@int,int,int,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.ByIndices",
-      "iconName": "Autodesk.DesignScript.Geometry.IndexGroup.ByIndices.int-int-int",
-      "creationName": "Autodesk.DesignScript.Geometry.IndexGroup.ByIndices@int,int,int",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.ByIndices.int-int-int.png",
+      "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.ByIndices@int,int,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.Count",
-      "iconName": "Autodesk.DesignScript.Geometry.IndexGroup.Count",
-      "creationName": "Autodesk.DesignScript.Geometry.IndexGroup.Count",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.Count.png",
+      "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.Count",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.A",
-      "iconName": "Autodesk.DesignScript.Geometry.IndexGroup.A",
-      "creationName": "Autodesk.DesignScript.Geometry.IndexGroup.A",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.A.png",
+      "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.A",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.B",
-      "iconName": "Autodesk.DesignScript.Geometry.IndexGroup.B",
-      "creationName": "Autodesk.DesignScript.Geometry.IndexGroup.B",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.B.png",
+      "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.B",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.C",
-      "iconName": "Autodesk.DesignScript.Geometry.IndexGroup.C",
-      "creationName": "Autodesk.DesignScript.Geometry.IndexGroup.C",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.C.png",
+      "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.C",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.IndexGroup.D",
-      "iconName": "Autodesk.DesignScript.Geometry.IndexGroup.D",
-      "creationName": "Autodesk.DesignScript.Geometry.IndexGroup.D",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.IndexGroup.D.png",
+      "contextData": "Autodesk.DesignScript.Geometry.IndexGroup.D",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Line.ByBestFitThroughPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Line.ByBestFitThroughPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.Line.ByBestFitThroughPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.ByBestFitThroughPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Line.ByBestFitThroughPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Line.ByTangency",
-      "iconName": "Autodesk.DesignScript.Geometry.Line.ByTangency",
-      "creationName": "Autodesk.DesignScript.Geometry.Line.ByTangency@Autodesk.DesignScript.Geometry.Curve,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.ByTangency.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Line.ByTangency@Autodesk.DesignScript.Geometry.Curve,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Line.ByStartPointDirectionLength",
-      "iconName": "Autodesk.DesignScript.Geometry.Line.ByStartPointDirectionLength",
-      "creationName": "Autodesk.DesignScript.Geometry.Line.ByStartPointDirectionLength@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.ByStartPointDirectionLength.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Line.ByStartPointDirectionLength@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Vector,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Line.Direction",
-      "iconName": "Autodesk.DesignScript.Geometry.Line.Direction",
-      "creationName": "Autodesk.DesignScript.Geometry.Line.Direction",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Line.Direction.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Line.Direction",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Mesh.ByPointsFaceIndices",
-      "iconName": "Autodesk.DesignScript.Geometry.Mesh.ByPointsFaceIndices",
-      "creationName": "Autodesk.DesignScript.Geometry.Mesh.ByPointsFaceIndices@Autodesk.DesignScript.Geometry.Point[],Autodesk.DesignScript.Geometry.IndexGroup[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.ByPointsFaceIndices.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Mesh.ByPointsFaceIndices@Autodesk.DesignScript.Geometry.Point[],Autodesk.DesignScript.Geometry.IndexGroup[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Mesh.FaceIndices",
-      "iconName": "Autodesk.DesignScript.Geometry.Mesh.FaceIndices",
-      "creationName": "Autodesk.DesignScript.Geometry.Mesh.FaceIndices",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.FaceIndices.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Mesh.FaceIndices",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Mesh.VertexNormals",
-      "iconName": "Autodesk.DesignScript.Geometry.Mesh.VertexNormals",
-      "creationName": "Autodesk.DesignScript.Geometry.Mesh.VertexNormals",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.VertexNormals.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Mesh.VertexNormals",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Mesh.VertexPositions",
-      "iconName": "Autodesk.DesignScript.Geometry.Mesh.VertexPositions",
-      "creationName": "Autodesk.DesignScript.Geometry.Mesh.VertexPositions",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Mesh.VertexPositions.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Mesh.VertexPositions",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPoints@Autodesk.DesignScript.Geometry.Point[][],int,int",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPoints@Autodesk.DesignScript.Geometry.Point[][],int,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangents",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangents",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangents@Autodesk.DesignScript.Geometry.Point[][],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangents.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangents@Autodesk.DesignScript.Geometry.Point[][],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangentsKnotsDerivatives",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangentsKnotsDerivatives",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangentsKnotsDerivatives@Autodesk.DesignScript.Geometry.Point[][],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],double[],double[],Autodesk.DesignScript.Geometry.Vector[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangentsKnotsDerivatives.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.ByPointsTangentsKnotsDerivatives@Autodesk.DesignScript.Geometry.Point[][],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],Autodesk.DesignScript.Geometry.Vector[],double[],double[],Autodesk.DesignScript.Geometry.Vector[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPoints@Autodesk.DesignScript.Geometry.Point[][],int,int",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPoints@Autodesk.DesignScript.Geometry.Point[][],int,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPointsWeightsKnots",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPointsWeightsKnots",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPointsWeightsKnots@Autodesk.DesignScript.Geometry.Point[][],double[][],double[],double[],int,int",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPointsWeightsKnots.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.ByControlPointsWeightsKnots@Autodesk.DesignScript.Geometry.Point[][],double[][],double[],double[],int,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.DegreeU",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.DegreeU",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.DegreeU",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.DegreeU.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.DegreeU",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.DegreeV",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.DegreeV",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.DegreeV",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.DegreeV.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.DegreeV",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsU",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsU",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsU",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsU.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsU",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsV",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsV",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsV",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsV.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.NumControlPointsV",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInU",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInU",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInU",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInU.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInU",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInV",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInV",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInV",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInV.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.IsPeriodicInV",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.IsRational",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.IsRational",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.IsRational",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.IsRational.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.IsRational",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.ControlPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.ControlPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.ControlPoints",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.ControlPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.ControlPoints",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.Weights",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.Weights",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.Weights",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.Weights.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.Weights",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.UKnots",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.UKnots",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.UKnots",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.UKnots.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.UKnots",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.NurbsSurface.VKnots",
-      "iconName": "Autodesk.DesignScript.Geometry.NurbsSurface.VKnots",
-      "creationName": "Autodesk.DesignScript.Geometry.NurbsSurface.VKnots",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.NurbsSurface.VKnots.png",
+      "contextData": "Autodesk.DesignScript.Geometry.NurbsSurface.VKnots",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.ByPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Polygon.ByPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.Polygon.ByPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.ByPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Polygon.ByPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.RegularPolygon",
-      "iconName": "Autodesk.DesignScript.Geometry.Polygon.RegularPolygon",
-      "creationName": "Autodesk.DesignScript.Geometry.Polygon.RegularPolygon@Autodesk.DesignScript.Geometry.Circle,int",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.RegularPolygon.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Polygon.RegularPolygon@Autodesk.DesignScript.Geometry.Circle,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.Points",
-      "iconName": "Autodesk.DesignScript.Geometry.Polygon.Points",
-      "creationName": "Autodesk.DesignScript.Geometry.Polygon.Points",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.Points.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Polygon.Points",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.PlaneDeviation",
-      "iconName": "Autodesk.DesignScript.Geometry.Polygon.PlaneDeviation",
-      "creationName": "Autodesk.DesignScript.Geometry.Polygon.PlaneDeviation",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.PlaneDeviation.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Polygon.PlaneDeviation",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.Corners",
-      "iconName": "Autodesk.DesignScript.Geometry.Polygon.Corners",
-      "creationName": "Autodesk.DesignScript.Geometry.Polygon.Corners",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.Corners.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Polygon.Corners",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.Center",
-      "iconName": "Autodesk.DesignScript.Geometry.Polygon.Center",
-      "creationName": "Autodesk.DesignScript.Geometry.Polygon.Center",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.Center.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Polygon.Center",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.SelfIntersections",
-      "iconName": "Autodesk.DesignScript.Geometry.Polygon.SelfIntersections",
-      "creationName": "Autodesk.DesignScript.Geometry.Polygon.SelfIntersections",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.SelfIntersections.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Polygon.SelfIntersections",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Polygon.ContainmentTest",
-      "iconName": "Autodesk.DesignScript.Geometry.Polygon.ContainmentTest",
-      "creationName": "Autodesk.DesignScript.Geometry.Polygon.ContainmentTest@Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Polygon.ContainmentTest.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Polygon.ContainmentTest@Autodesk.DesignScript.Geometry.Point",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints.Point1",
-      "creationName": "Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints.Point1.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints.Point-Point-Point-Point",
-      "creationName": "Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints.Point-Point-Point-Point.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Rectangle.ByCornerPoints@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength",
-      "iconName": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength.double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength@double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength.double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength@double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength",
-      "iconName": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength.Plane-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength@Autodesk.DesignScript.Geometry.Plane,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength.Plane-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength@Autodesk.DesignScript.Geometry.Plane,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength",
-      "iconName": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength.CoordinateSystem-double-double",
-      "creationName": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength.CoordinateSystem-double-double.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.Width",
-      "iconName": "Autodesk.DesignScript.Geometry.Rectangle.Width",
-      "creationName": "Autodesk.DesignScript.Geometry.Rectangle.Width",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.Width.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Rectangle.Width",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Rectangle.Height",
-      "iconName": "Autodesk.DesignScript.Geometry.Rectangle.Height",
-      "creationName": "Autodesk.DesignScript.Geometry.Rectangle.Height",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Rectangle.Height.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Rectangle.Height",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius",
-      "iconName": "Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius",
-      "creationName": "Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Sphere.ByFourPoints",
-      "iconName": "Autodesk.DesignScript.Geometry.Sphere.ByFourPoints",
-      "creationName": "Autodesk.DesignScript.Geometry.Sphere.ByFourPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.ByFourPoints.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Sphere.ByFourPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Sphere.ByBestFit",
-      "iconName": "Autodesk.DesignScript.Geometry.Sphere.ByBestFit",
-      "creationName": "Autodesk.DesignScript.Geometry.Sphere.ByBestFit@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.ByBestFit.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Sphere.ByBestFit@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Sphere.CenterPoint",
-      "iconName": "Autodesk.DesignScript.Geometry.Sphere.CenterPoint",
-      "creationName": "Autodesk.DesignScript.Geometry.Sphere.CenterPoint",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.CenterPoint.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Sphere.CenterPoint",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "Autodesk.DesignScript.Geometry.Sphere.Radius",
-      "iconName": "Autodesk.DesignScript.Geometry.Sphere.Radius",
-      "creationName": "Autodesk.DesignScript.Geometry.Sphere.Radius",
+      "iconName": "/src/resources/icons/Autodesk.DesignScript.Geometry.Sphere.Radius.png",
+      "contextData": "Autodesk.DesignScript.Geometry.Sphere.Radius",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Red",
-      "iconName": "DSCore.Color.Red",
-      "creationName": "DSCore.Color.Red",
+      "iconName": "/src/resources/icons/DSCore.Color.Red.png",
+      "contextData": "DSCore.Color.Red",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Green",
-      "iconName": "DSCore.Color.Green",
-      "creationName": "DSCore.Color.Green",
+      "iconName": "/src/resources/icons/DSCore.Color.Green.png",
+      "contextData": "DSCore.Color.Green",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Blue",
-      "iconName": "DSCore.Color.Blue",
-      "creationName": "DSCore.Color.Blue",
+      "iconName": "/src/resources/icons/DSCore.Color.Blue.png",
+      "contextData": "DSCore.Color.Blue",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Alpha",
-      "iconName": "DSCore.Color.Alpha",
-      "creationName": "DSCore.Color.Alpha",
+      "iconName": "/src/resources/icons/DSCore.Color.Alpha.png",
+      "contextData": "DSCore.Color.Alpha",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Color.ByARGB",
-      "iconName": "DSCore.Color.ByARGB",
-      "creationName": "DSCore.Color.ByARGB@int,int,int,int",
+      "iconName": "/src/resources/icons/DSCore.Color.ByARGB.png",
+      "contextData": "DSCore.Color.ByARGB@int,int,int,int",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Brightness",
-      "iconName": "DSCore.Color.Brightness",
-      "creationName": "DSCore.Color.Brightness@DSCore.Color",
+      "iconName": "/src/resources/icons/DSCore.Color.Brightness.png",
+      "contextData": "DSCore.Color.Brightness@DSCore.Color",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Saturation",
-      "iconName": "DSCore.Color.Saturation",
-      "creationName": "DSCore.Color.Saturation@DSCore.Color",
+      "iconName": "/src/resources/icons/DSCore.Color.Saturation.png",
+      "contextData": "DSCore.Color.Saturation@DSCore.Color",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Hue",
-      "iconName": "DSCore.Color.Hue",
-      "creationName": "DSCore.Color.Hue@DSCore.Color",
+      "iconName": "/src/resources/icons/DSCore.Color.Hue.png",
+      "contextData": "DSCore.Color.Hue@DSCore.Color",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Components",
-      "iconName": "DSCore.Color.Components",
-      "creationName": "DSCore.Color.Components@DSCore.Color",
+      "iconName": "/src/resources/icons/DSCore.Color.Components.png",
+      "contextData": "DSCore.Color.Components@DSCore.Color",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Add",
-      "iconName": "DSCore.Color.Add",
-      "creationName": "DSCore.Color.Add@DSCore.Color,DSCore.Color",
+      "iconName": "/src/resources/icons/DSCore.Color.Add.png",
+      "contextData": "DSCore.Color.Add@DSCore.Color,DSCore.Color",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Multiply",
-      "iconName": "DSCore.Color.Multiply",
-      "creationName": "DSCore.Color.Multiply@DSCore.Color,double",
+      "iconName": "/src/resources/icons/DSCore.Color.Multiply.png",
+      "contextData": "DSCore.Color.Multiply@DSCore.Color,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "DSCore.Color.Divide",
-      "iconName": "DSCore.Color.Divide",
-      "creationName": "DSCore.Color.Divide@DSCore.Color,double",
+      "iconName": "/src/resources/icons/DSCore.Color.Divide.png",
+      "contextData": "DSCore.Color.Divide@DSCore.Color,double",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "DSCore.ColorRange2D.ByColorsAndParameters",
-      "iconName": "DSCore.ColorRange2D.ByColorsAndParameters",
-      "creationName": "DSCore.ColorRange2D.ByColorsAndParameters@DSCore.Color[],Autodesk.DesignScript.Geometry.UV[]",
+      "iconName": "/src/resources/icons/DSCore.ColorRange2D.ByColorsAndParameters.png",
+      "contextData": "DSCore.ColorRange2D.ByColorsAndParameters@DSCore.Color[],Autodesk.DesignScript.Geometry.UV[]",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "DSCore.ColorRange2D.GetColorAtParameter",
-      "iconName": "DSCore.ColorRange2D.GetColorAtParameter",
-      "creationName": "DSCore.ColorRange2D.GetColorAtParameter@Autodesk.DesignScript.Geometry.UV",
+      "iconName": "/src/resources/icons/DSCore.ColorRange2D.GetColorAtParameter.png",
+      "contextData": "DSCore.ColorRange2D.GetColorAtParameter@Autodesk.DesignScript.Geometry.UV",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.MinValue",
-      "iconName": "DSCore.DateTime.MinValue",
-      "creationName": "DSCore.DateTime.MinValue",
+      "iconName": "/src/resources/icons/DSCore.DateTime.MinValue.png",
+      "contextData": "DSCore.DateTime.MinValue",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.MaxValue",
-      "iconName": "DSCore.DateTime.MaxValue",
-      "creationName": "DSCore.DateTime.MaxValue",
+      "iconName": "/src/resources/icons/DSCore.DateTime.MaxValue.png",
+      "contextData": "DSCore.DateTime.MaxValue",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.Now",
-      "iconName": "DSCore.DateTime.Now",
-      "creationName": "DSCore.DateTime.Now",
+      "iconName": "/src/resources/icons/DSCore.DateTime.Now.png",
+      "contextData": "DSCore.DateTime.Now",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.Today",
-      "iconName": "DSCore.DateTime.Today",
-      "creationName": "DSCore.DateTime.Today",
+      "iconName": "/src/resources/icons/DSCore.DateTime.Today.png",
+      "contextData": "DSCore.DateTime.Today",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.ByDate",
-      "iconName": "DSCore.DateTime.ByDate",
-      "creationName": "DSCore.DateTime.ByDate@int,int,int",
+      "iconName": "/src/resources/icons/DSCore.DateTime.ByDate.png",
+      "contextData": "DSCore.DateTime.ByDate@int,int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.ByDateAndTime",
-      "iconName": "DSCore.DateTime.ByDateAndTime",
-      "creationName": "DSCore.DateTime.ByDateAndTime@int,int,int,int,int,int,int",
+      "iconName": "/src/resources/icons/DSCore.DateTime.ByDateAndTime.png",
+      "contextData": "DSCore.DateTime.ByDateAndTime@int,int,int,int,int,int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.SubtractTimeSpan",
-      "iconName": "DSCore.DateTime.SubtractTimeSpan",
-      "creationName": "DSCore.DateTime.SubtractTimeSpan@var,var",
+      "iconName": "/src/resources/icons/DSCore.DateTime.SubtractTimeSpan.png",
+      "contextData": "DSCore.DateTime.SubtractTimeSpan@var,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.AddTimeSpan",
-      "iconName": "DSCore.DateTime.AddTimeSpan",
-      "creationName": "DSCore.DateTime.AddTimeSpan@var,var",
+      "iconName": "/src/resources/icons/DSCore.DateTime.AddTimeSpan.png",
+      "contextData": "DSCore.DateTime.AddTimeSpan@var,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.DaysInMonth",
-      "iconName": "DSCore.DateTime.DaysInMonth",
-      "creationName": "DSCore.DateTime.DaysInMonth@int,int",
+      "iconName": "/src/resources/icons/DSCore.DateTime.DaysInMonth.png",
+      "contextData": "DSCore.DateTime.DaysInMonth@int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.IsDaylightSavingsTime",
-      "iconName": "DSCore.DateTime.IsDaylightSavingsTime",
-      "creationName": "DSCore.DateTime.IsDaylightSavingsTime@var",
+      "iconName": "/src/resources/icons/DSCore.DateTime.IsDaylightSavingsTime.png",
+      "contextData": "DSCore.DateTime.IsDaylightSavingsTime@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.IsLeapYear",
-      "iconName": "DSCore.DateTime.IsLeapYear",
-      "creationName": "DSCore.DateTime.IsLeapYear@int",
+      "iconName": "/src/resources/icons/DSCore.DateTime.IsLeapYear.png",
+      "contextData": "DSCore.DateTime.IsLeapYear@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.FromString",
-      "iconName": "DSCore.DateTime.FromString",
-      "creationName": "DSCore.DateTime.FromString@string",
+      "iconName": "/src/resources/icons/DSCore.DateTime.FromString.png",
+      "contextData": "DSCore.DateTime.FromString@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.Date",
-      "iconName": "DSCore.DateTime.Date",
-      "creationName": "DSCore.DateTime.Date@var",
+      "iconName": "/src/resources/icons/DSCore.DateTime.Date.png",
+      "contextData": "DSCore.DateTime.Date@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.Components",
-      "iconName": "DSCore.DateTime.Components",
-      "creationName": "DSCore.DateTime.Components@var",
+      "iconName": "/src/resources/icons/DSCore.DateTime.Components.png",
+      "contextData": "DSCore.DateTime.Components@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.DayOfWeek",
-      "iconName": "DSCore.DateTime.DayOfWeek",
-      "creationName": "DSCore.DateTime.DayOfWeek@var",
+      "iconName": "/src/resources/icons/DSCore.DateTime.DayOfWeek.png",
+      "contextData": "DSCore.DateTime.DayOfWeek@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.DayOfYear",
-      "iconName": "DSCore.DateTime.DayOfYear",
-      "creationName": "DSCore.DateTime.DayOfYear@var",
+      "iconName": "/src/resources/icons/DSCore.DateTime.DayOfYear.png",
+      "contextData": "DSCore.DateTime.DayOfYear@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DateTime.TimeOfDay",
-      "iconName": "DSCore.DateTime.TimeOfDay",
-      "creationName": "DSCore.DateTime.TimeOfDay@var",
+      "iconName": "/src/resources/icons/DSCore.DateTime.TimeOfDay.png",
+      "contextData": "DSCore.DateTime.TimeOfDay@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Sunday",
-      "iconName": "DSCore.DayOfWeek.Sunday",
-      "creationName": "DSCore.DayOfWeek.Sunday",
+      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Sunday.png",
+      "contextData": "DSCore.DayOfWeek.Sunday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Monday",
-      "iconName": "DSCore.DayOfWeek.Monday",
-      "creationName": "DSCore.DayOfWeek.Monday",
+      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Monday.png",
+      "contextData": "DSCore.DayOfWeek.Monday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Tuesday",
-      "iconName": "DSCore.DayOfWeek.Tuesday",
-      "creationName": "DSCore.DayOfWeek.Tuesday",
+      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Tuesday.png",
+      "contextData": "DSCore.DayOfWeek.Tuesday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Wednesday",
-      "iconName": "DSCore.DayOfWeek.Wednesday",
-      "creationName": "DSCore.DayOfWeek.Wednesday",
+      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Wednesday.png",
+      "contextData": "DSCore.DayOfWeek.Wednesday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Thursday",
-      "iconName": "DSCore.DayOfWeek.Thursday",
-      "creationName": "DSCore.DayOfWeek.Thursday",
+      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Thursday.png",
+      "contextData": "DSCore.DayOfWeek.Thursday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Friday",
-      "iconName": "DSCore.DayOfWeek.Friday",
-      "creationName": "DSCore.DayOfWeek.Friday",
+      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Friday.png",
+      "contextData": "DSCore.DayOfWeek.Friday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.DayOfWeek.Saturday",
-      "iconName": "DSCore.DayOfWeek.Saturday",
-      "creationName": "DSCore.DayOfWeek.Saturday",
+      "iconName": "/src/resources/icons/DSCore.DayOfWeek.Saturday.png",
+      "contextData": "DSCore.DayOfWeek.Saturday",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.ByDateDifference",
-      "iconName": "DSCore.TimeSpan.ByDateDifference",
-      "creationName": "DSCore.TimeSpan.ByDateDifference@var,var",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.ByDateDifference.png",
+      "contextData": "DSCore.TimeSpan.ByDateDifference@var,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Zero",
-      "iconName": "DSCore.TimeSpan.Zero",
-      "creationName": "DSCore.TimeSpan.Zero",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.Zero.png",
+      "contextData": "DSCore.TimeSpan.Zero",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.MaxValue",
-      "iconName": "DSCore.TimeSpan.MaxValue",
-      "creationName": "DSCore.TimeSpan.MaxValue",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.MaxValue.png",
+      "contextData": "DSCore.TimeSpan.MaxValue",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.MinValue",
-      "iconName": "DSCore.TimeSpan.MinValue",
-      "creationName": "DSCore.TimeSpan.MinValue",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.MinValue.png",
+      "contextData": "DSCore.TimeSpan.MinValue",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Create",
-      "iconName": "DSCore.TimeSpan.Create",
-      "creationName": "DSCore.TimeSpan.Create@double,double,double,double,double",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.Create.png",
+      "contextData": "DSCore.TimeSpan.Create@double,double,double,double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Scale",
-      "iconName": "DSCore.TimeSpan.Scale",
-      "creationName": "DSCore.TimeSpan.Scale@var,double",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.Scale.png",
+      "contextData": "DSCore.TimeSpan.Scale@var,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Negate",
-      "iconName": "DSCore.TimeSpan.Negate",
-      "creationName": "DSCore.TimeSpan.Negate@var",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.Negate.png",
+      "contextData": "DSCore.TimeSpan.Negate@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Add",
-      "iconName": "DSCore.TimeSpan.Add",
-      "creationName": "DSCore.TimeSpan.Add@var,var",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.Add.png",
+      "contextData": "DSCore.TimeSpan.Add@var,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Subtract",
-      "iconName": "DSCore.TimeSpan.Subtract",
-      "creationName": "DSCore.TimeSpan.Subtract@var,var",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.Subtract.png",
+      "contextData": "DSCore.TimeSpan.Subtract@var,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.FromString",
-      "iconName": "DSCore.TimeSpan.FromString",
-      "creationName": "DSCore.TimeSpan.FromString@string",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.FromString.png",
+      "contextData": "DSCore.TimeSpan.FromString@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.Components",
-      "iconName": "DSCore.TimeSpan.Components",
-      "creationName": "DSCore.TimeSpan.Components@var",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.Components.png",
+      "contextData": "DSCore.TimeSpan.Components@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.TotalDays",
-      "iconName": "DSCore.TimeSpan.TotalDays",
-      "creationName": "DSCore.TimeSpan.TotalDays@var",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.TotalDays.png",
+      "contextData": "DSCore.TimeSpan.TotalDays@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.TotalHours",
-      "iconName": "DSCore.TimeSpan.TotalHours",
-      "creationName": "DSCore.TimeSpan.TotalHours@var",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.TotalHours.png",
+      "contextData": "DSCore.TimeSpan.TotalHours@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.TotalMinutes",
-      "iconName": "DSCore.TimeSpan.TotalMinutes",
-      "creationName": "DSCore.TimeSpan.TotalMinutes@var",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.TotalMinutes.png",
+      "contextData": "DSCore.TimeSpan.TotalMinutes@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.TotalSeconds",
-      "iconName": "DSCore.TimeSpan.TotalSeconds",
-      "creationName": "DSCore.TimeSpan.TotalSeconds@var",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.TotalSeconds.png",
+      "contextData": "DSCore.TimeSpan.TotalSeconds@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.TimeSpan.TotalMilliseconds",
-      "iconName": "DSCore.TimeSpan.TotalMilliseconds",
-      "creationName": "DSCore.TimeSpan.TotalMilliseconds@var",
+      "iconName": "/src/resources/icons/DSCore.TimeSpan.TotalMilliseconds.png",
+      "contextData": "DSCore.TimeSpan.TotalMilliseconds@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Formula.Evaluate",
-      "iconName": "DSCore.Formula.Evaluate",
-      "creationName": "DSCore.Formula.Evaluate@string,string[],var[]",
+      "iconName": "/src/resources/icons/DSCore.Formula.Evaluate.png",
+      "contextData": "DSCore.Formula.Evaluate@string,string[],var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Logic.Xor",
-      "iconName": "DSCore.Logic.Xor",
-      "creationName": "DSCore.Logic.Xor@bool,bool",
+      "iconName": "/src/resources/icons/DSCore.Logic.Xor.png",
+      "contextData": "DSCore.Logic.Xor@bool,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Empty",
-      "iconName": "DSCore.List.Empty",
-      "creationName": "DSCore.List.Empty",
+      "iconName": "/src/resources/icons/DSCore.List.Empty.png",
+      "contextData": "DSCore.List.Empty",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.List.UniqueItems",
-      "iconName": "DSCore.List.UniqueItems",
-      "creationName": "DSCore.List.UniqueItems@var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.UniqueItems.png",
+      "contextData": "DSCore.List.UniqueItems@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.ContainsItem",
-      "iconName": "DSCore.List.ContainsItem",
-      "creationName": "DSCore.List.ContainsItem@var[]..[],var",
+      "iconName": "/src/resources/icons/DSCore.List.ContainsItem.png",
+      "contextData": "DSCore.List.ContainsItem@var[]..[],var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Reverse",
-      "iconName": "DSCore.List.Reverse",
-      "creationName": "DSCore.List.Reverse@var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.Reverse.png",
+      "contextData": "DSCore.List.Reverse@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Sublists",
-      "iconName": "DSCore.List.Sublists",
-      "creationName": "DSCore.List.Sublists@var[]..[],var[]..[],int",
+      "iconName": "/src/resources/icons/DSCore.List.Sublists.png",
+      "contextData": "DSCore.List.Sublists@var[]..[],var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Sort",
-      "iconName": "DSCore.List.Sort",
-      "creationName": "DSCore.List.Sort@var[]",
+      "iconName": "/src/resources/icons/DSCore.List.Sort.png",
+      "contextData": "DSCore.List.Sort@var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.MinimumItem",
-      "iconName": "DSCore.List.MinimumItem",
-      "creationName": "DSCore.List.MinimumItem@var[]",
+      "iconName": "/src/resources/icons/DSCore.List.MinimumItem.png",
+      "contextData": "DSCore.List.MinimumItem@var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.MaximumItem",
-      "iconName": "DSCore.List.MaximumItem",
-      "creationName": "DSCore.List.MaximumItem@var[]",
+      "iconName": "/src/resources/icons/DSCore.List.MaximumItem.png",
+      "contextData": "DSCore.List.MaximumItem@var[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.FilterByBoolMask",
-      "iconName": "DSCore.List.FilterByBoolMask",
-      "creationName": "DSCore.List.FilterByBoolMask@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.FilterByBoolMask.png",
+      "contextData": "DSCore.List.FilterByBoolMask@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Deconstruct",
-      "iconName": "DSCore.List.Deconstruct",
-      "creationName": "DSCore.List.Deconstruct@var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.Deconstruct.png",
+      "contextData": "DSCore.List.Deconstruct@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.SortByKey",
-      "iconName": "DSCore.List.SortByKey",
-      "creationName": "DSCore.List.SortByKey@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.SortByKey.png",
+      "contextData": "DSCore.List.SortByKey@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.GroupByKey",
-      "iconName": "DSCore.List.GroupByKey",
-      "creationName": "DSCore.List.GroupByKey@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.GroupByKey.png",
+      "contextData": "DSCore.List.GroupByKey@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.AddItemToFront",
-      "iconName": "DSCore.List.AddItemToFront",
-      "creationName": "DSCore.List.AddItemToFront@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.AddItemToFront.png",
+      "contextData": "DSCore.List.AddItemToFront@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.AddItemToEnd",
-      "iconName": "DSCore.List.AddItemToEnd",
-      "creationName": "DSCore.List.AddItemToEnd@var[]..[],var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.AddItemToEnd.png",
+      "contextData": "DSCore.List.AddItemToEnd@var[]..[],var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.TakeItems",
-      "iconName": "DSCore.List.TakeItems",
-      "creationName": "DSCore.List.TakeItems@var[]..[],int",
+      "iconName": "/src/resources/icons/DSCore.List.TakeItems.png",
+      "contextData": "DSCore.List.TakeItems@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.DropItems",
-      "iconName": "DSCore.List.DropItems",
-      "creationName": "DSCore.List.DropItems@var[]..[],int",
+      "iconName": "/src/resources/icons/DSCore.List.DropItems.png",
+      "contextData": "DSCore.List.DropItems@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.ShiftIndices",
-      "iconName": "DSCore.List.ShiftIndices",
-      "creationName": "DSCore.List.ShiftIndices@var[]..[],int",
+      "iconName": "/src/resources/icons/DSCore.List.ShiftIndices.png",
+      "contextData": "DSCore.List.ShiftIndices@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.GetItemAtIndex",
-      "iconName": "DSCore.List.GetItemAtIndex",
-      "creationName": "DSCore.List.GetItemAtIndex@var[]..[],int",
+      "iconName": "/src/resources/icons/DSCore.List.GetItemAtIndex.png",
+      "contextData": "DSCore.List.GetItemAtIndex@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.ReplaceItemAtIndex",
-      "iconName": "DSCore.List.ReplaceItemAtIndex",
-      "creationName": "DSCore.List.ReplaceItemAtIndex@var[]..[],int,var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.ReplaceItemAtIndex.png",
+      "contextData": "DSCore.List.ReplaceItemAtIndex@var[]..[],int,var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Slice",
-      "iconName": "DSCore.List.Slice",
-      "creationName": "DSCore.List.Slice@var[]..[],int,int,int",
+      "iconName": "/src/resources/icons/DSCore.List.Slice.png",
+      "contextData": "DSCore.List.Slice@var[]..[],int,int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.RemoveItemAtIndex",
-      "iconName": "DSCore.List.RemoveItemAtIndex",
-      "creationName": "DSCore.List.RemoveItemAtIndex@var[]..[],int[]",
+      "iconName": "/src/resources/icons/DSCore.List.RemoveItemAtIndex.png",
+      "contextData": "DSCore.List.RemoveItemAtIndex@var[]..[],int[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.DropEveryNthItem",
-      "iconName": "DSCore.List.DropEveryNthItem",
-      "creationName": "DSCore.List.DropEveryNthItem@var[]..[],int,int",
+      "iconName": "/src/resources/icons/DSCore.List.DropEveryNthItem.png",
+      "contextData": "DSCore.List.DropEveryNthItem@var[]..[],int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.TakeEveryNthItem",
-      "iconName": "DSCore.List.TakeEveryNthItem",
-      "creationName": "DSCore.List.TakeEveryNthItem@var[]..[],int,int",
+      "iconName": "/src/resources/icons/DSCore.List.TakeEveryNthItem.png",
+      "contextData": "DSCore.List.TakeEveryNthItem@var[]..[],int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.IsEmpty",
-      "iconName": "DSCore.List.IsEmpty",
-      "creationName": "DSCore.List.IsEmpty@var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.IsEmpty.png",
+      "contextData": "DSCore.List.IsEmpty@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Count",
-      "iconName": "DSCore.List.Count",
-      "creationName": "DSCore.List.Count@var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.Count.png",
+      "contextData": "DSCore.List.Count@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Join",
-      "iconName": "DSCore.List.Join",
-      "creationName": "DSCore.List.Join@var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.Join.png",
+      "contextData": "DSCore.List.Join@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.FirstItem",
-      "iconName": "DSCore.List.FirstItem",
-      "creationName": "DSCore.List.FirstItem@var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.FirstItem.png",
+      "contextData": "DSCore.List.FirstItem@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.RestOfItems",
-      "iconName": "DSCore.List.RestOfItems",
-      "creationName": "DSCore.List.RestOfItems@var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.RestOfItems.png",
+      "contextData": "DSCore.List.RestOfItems@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Chop",
-      "iconName": "DSCore.List.Chop",
-      "creationName": "DSCore.List.Chop@var[]..[],int[]",
+      "iconName": "/src/resources/icons/DSCore.List.Chop.png",
+      "contextData": "DSCore.List.Chop@var[]..[],int[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.DiagonalRight",
-      "iconName": "DSCore.List.DiagonalRight",
-      "creationName": "DSCore.List.DiagonalRight@var[]..[],int",
+      "iconName": "/src/resources/icons/DSCore.List.DiagonalRight.png",
+      "contextData": "DSCore.List.DiagonalRight@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.DiagonalLeft",
-      "iconName": "DSCore.List.DiagonalLeft",
-      "creationName": "DSCore.List.DiagonalLeft@var[]..[],int",
+      "iconName": "/src/resources/icons/DSCore.List.DiagonalLeft.png",
+      "contextData": "DSCore.List.DiagonalLeft@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Transpose",
-      "iconName": "DSCore.List.Transpose",
-      "creationName": "DSCore.List.Transpose@var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.Transpose.png",
+      "contextData": "DSCore.List.Transpose@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Clean",
-      "iconName": "DSCore.List.Clean",
-      "creationName": "DSCore.List.Clean@var[]..[],bool",
+      "iconName": "/src/resources/icons/DSCore.List.Clean.png",
+      "contextData": "DSCore.List.Clean@var[]..[],bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.OfRepeatedItem",
-      "iconName": "DSCore.List.OfRepeatedItem",
-      "creationName": "DSCore.List.OfRepeatedItem@var[]..[],int",
+      "iconName": "/src/resources/icons/DSCore.List.OfRepeatedItem.png",
+      "contextData": "DSCore.List.OfRepeatedItem@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Cycle",
-      "iconName": "DSCore.List.Cycle",
-      "creationName": "DSCore.List.Cycle@var[]..[],int",
+      "iconName": "/src/resources/icons/DSCore.List.Cycle.png",
+      "contextData": "DSCore.List.Cycle@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.LastItem",
-      "iconName": "DSCore.List.LastItem",
-      "creationName": "DSCore.List.LastItem@var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.LastItem.png",
+      "contextData": "DSCore.List.LastItem@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Shuffle",
-      "iconName": "DSCore.List.Shuffle",
-      "creationName": "DSCore.List.Shuffle@var[]..[]",
+      "iconName": "/src/resources/icons/DSCore.List.Shuffle.png",
+      "contextData": "DSCore.List.Shuffle@var[]..[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Permutations",
-      "iconName": "DSCore.List.Permutations",
-      "creationName": "DSCore.List.Permutations@var[]..[],int",
+      "iconName": "/src/resources/icons/DSCore.List.Permutations.png",
+      "contextData": "DSCore.List.Permutations@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Combinations",
-      "iconName": "DSCore.List.Combinations",
-      "creationName": "DSCore.List.Combinations@var[]..[],int,bool",
+      "iconName": "/src/resources/icons/DSCore.List.Combinations.png",
+      "contextData": "DSCore.List.Combinations@var[]..[],int,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.FirstIndexOf",
-      "iconName": "DSCore.List.FirstIndexOf",
-      "creationName": "DSCore.List.FirstIndexOf@var[]..[],var",
+      "iconName": "/src/resources/icons/DSCore.List.FirstIndexOf.png",
+      "contextData": "DSCore.List.FirstIndexOf@var[]..[],var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.AllIndicesOf",
-      "iconName": "DSCore.List.AllIndicesOf",
-      "creationName": "DSCore.List.AllIndicesOf@var[]..[],var",
+      "iconName": "/src/resources/icons/DSCore.List.AllIndicesOf.png",
+      "contextData": "DSCore.List.AllIndicesOf@var[]..[],var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.List.Flatten",
-      "iconName": "DSCore.List.Flatten",
-      "creationName": "DSCore.List.Flatten@var[]..[],int",
+      "iconName": "/src/resources/icons/DSCore.List.Flatten.png",
+      "contextData": "DSCore.List.Flatten@var[]..[],int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Random",
-      "iconName": "DSCore.Math.Random.int",
-      "creationName": "DSCore.Math.Random@int",
+      "iconName": "/src/resources/icons/DSCore.Math.Random.int.png",
+      "contextData": "DSCore.Math.Random@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Random",
-      "iconName": "DSCore.Math.Random.double-double",
-      "creationName": "DSCore.Math.Random@double,double",
+      "iconName": "/src/resources/icons/DSCore.Math.Random.double-double.png",
+      "contextData": "DSCore.Math.Random@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.RandomList",
-      "iconName": "DSCore.Math.RandomList",
-      "creationName": "DSCore.Math.RandomList@int",
+      "iconName": "/src/resources/icons/DSCore.Math.RandomList.png",
+      "contextData": "DSCore.Math.RandomList@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.PiTimes2",
-      "iconName": "DSCore.Math.PiTimes2",
-      "creationName": "DSCore.Math.PiTimes2",
+      "iconName": "/src/resources/icons/DSCore.Math.PiTimes2.png",
+      "contextData": "DSCore.Math.PiTimes2",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Average",
-      "iconName": "DSCore.Math.Average",
-      "creationName": "DSCore.Math.Average@double[]",
+      "iconName": "/src/resources/icons/DSCore.Math.Average.png",
+      "contextData": "DSCore.Math.Average@double[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.RemapRange",
-      "iconName": "DSCore.Math.RemapRange",
-      "creationName": "DSCore.Math.RemapRange@double[],double,double",
+      "iconName": "/src/resources/icons/DSCore.Math.RemapRange.png",
+      "contextData": "DSCore.Math.RemapRange@double[],double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.PI",
-      "iconName": "DSCore.Math.PI",
-      "creationName": "DSCore.Math.PI",
+      "iconName": "/src/resources/icons/DSCore.Math.PI.png",
+      "contextData": "DSCore.Math.PI",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Math.E",
-      "iconName": "DSCore.Math.E",
-      "creationName": "DSCore.Math.E",
+      "iconName": "/src/resources/icons/DSCore.Math.E.png",
+      "contextData": "DSCore.Math.E",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Math.GoldenRatio",
-      "iconName": "DSCore.Math.GoldenRatio",
-      "creationName": "DSCore.Math.GoldenRatio",
+      "iconName": "/src/resources/icons/DSCore.Math.GoldenRatio.png",
+      "contextData": "DSCore.Math.GoldenRatio",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DSCore.Math.RadiansToDegrees",
-      "iconName": "DSCore.Math.RadiansToDegrees",
-      "creationName": "DSCore.Math.RadiansToDegrees@double",
+      "iconName": "/src/resources/icons/DSCore.Math.RadiansToDegrees.png",
+      "contextData": "DSCore.Math.RadiansToDegrees@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.DegreesToRadians",
-      "iconName": "DSCore.Math.DegreesToRadians",
-      "creationName": "DSCore.Math.DegreesToRadians@double",
+      "iconName": "/src/resources/icons/DSCore.Math.DegreesToRadians.png",
+      "contextData": "DSCore.Math.DegreesToRadians@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Abs",
-      "iconName": "DSCore.Math.Abs.double",
-      "creationName": "DSCore.Math.Abs@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Abs.double.png",
+      "contextData": "DSCore.Math.Abs@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Abs",
-      "iconName": "DSCore.Math.Abs.int",
-      "creationName": "DSCore.Math.Abs@int",
+      "iconName": "/src/resources/icons/DSCore.Math.Abs.int.png",
+      "contextData": "DSCore.Math.Abs@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Acos",
-      "iconName": "DSCore.Math.Acos",
-      "creationName": "DSCore.Math.Acos@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Acos.png",
+      "contextData": "DSCore.Math.Acos@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Asin",
-      "iconName": "DSCore.Math.Asin",
-      "creationName": "DSCore.Math.Asin@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Asin.png",
+      "contextData": "DSCore.Math.Asin@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Atan",
-      "iconName": "DSCore.Math.Atan",
-      "creationName": "DSCore.Math.Atan@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Atan.png",
+      "contextData": "DSCore.Math.Atan@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Atan2",
-      "iconName": "DSCore.Math.Atan2",
-      "creationName": "DSCore.Math.Atan2@double,double",
+      "iconName": "/src/resources/icons/DSCore.Math.Atan2.png",
+      "contextData": "DSCore.Math.Atan2@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Ceiling",
-      "iconName": "DSCore.Math.Ceiling",
-      "creationName": "DSCore.Math.Ceiling@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Ceiling.png",
+      "contextData": "DSCore.Math.Ceiling@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Cos",
-      "iconName": "DSCore.Math.Cos",
-      "creationName": "DSCore.Math.Cos@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Cos.png",
+      "contextData": "DSCore.Math.Cos@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Cosh",
-      "iconName": "DSCore.Math.Cosh",
-      "creationName": "DSCore.Math.Cosh@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Cosh.png",
+      "contextData": "DSCore.Math.Cosh@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.DivRem",
-      "iconName": "DSCore.Math.DivRem",
-      "creationName": "DSCore.Math.DivRem@int,int",
+      "iconName": "/src/resources/icons/DSCore.Math.DivRem.png",
+      "contextData": "DSCore.Math.DivRem@int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Exp",
-      "iconName": "DSCore.Math.Exp",
-      "creationName": "DSCore.Math.Exp@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Exp.png",
+      "contextData": "DSCore.Math.Exp@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Floor",
-      "iconName": "DSCore.Math.Floor",
-      "creationName": "DSCore.Math.Floor@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Floor.png",
+      "contextData": "DSCore.Math.Floor@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Log",
-      "iconName": "DSCore.Math.Log.double",
-      "creationName": "DSCore.Math.Log@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Log.double.png",
+      "contextData": "DSCore.Math.Log@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Log",
-      "iconName": "DSCore.Math.Log.double-double",
-      "creationName": "DSCore.Math.Log@double,double",
+      "iconName": "/src/resources/icons/DSCore.Math.Log.double-double.png",
+      "contextData": "DSCore.Math.Log@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Log10",
-      "iconName": "DSCore.Math.Log10",
-      "creationName": "DSCore.Math.Log10@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Log10.png",
+      "contextData": "DSCore.Math.Log10@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Max",
-      "iconName": "DSCore.Math.Max.double-double",
-      "creationName": "DSCore.Math.Max@double,double",
+      "iconName": "/src/resources/icons/DSCore.Math.Max.double-double.png",
+      "contextData": "DSCore.Math.Max@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Max",
-      "iconName": "DSCore.Math.Max.int-int",
-      "creationName": "DSCore.Math.Max@int,int",
+      "iconName": "/src/resources/icons/DSCore.Math.Max.int-int.png",
+      "contextData": "DSCore.Math.Max@int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Min",
-      "iconName": "DSCore.Math.Min.double-double",
-      "creationName": "DSCore.Math.Min@double,double",
+      "iconName": "/src/resources/icons/DSCore.Math.Min.double-double.png",
+      "contextData": "DSCore.Math.Min@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Min",
-      "iconName": "DSCore.Math.Min.int-int",
-      "creationName": "DSCore.Math.Min@int,int",
+      "iconName": "/src/resources/icons/DSCore.Math.Min.int-int.png",
+      "contextData": "DSCore.Math.Min@int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Pow",
-      "iconName": "DSCore.Math.Pow",
-      "creationName": "DSCore.Math.Pow@double,double",
+      "iconName": "/src/resources/icons/DSCore.Math.Pow.png",
+      "contextData": "DSCore.Math.Pow@double,double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Rand",
-      "iconName": "DSCore.Math.Rand",
-      "creationName": "DSCore.Math.Rand",
+      "iconName": "/src/resources/icons/DSCore.Math.Rand.png",
+      "contextData": "DSCore.Math.Rand",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Round",
-      "iconName": "DSCore.Math.Round.double",
-      "creationName": "DSCore.Math.Round@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Round.double.png",
+      "contextData": "DSCore.Math.Round@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Round",
-      "iconName": "DSCore.Math.Round.double-int",
-      "creationName": "DSCore.Math.Round@double,int",
+      "iconName": "/src/resources/icons/DSCore.Math.Round.double-int.png",
+      "contextData": "DSCore.Math.Round@double,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Sign",
-      "iconName": "DSCore.Math.Sign.double",
-      "creationName": "DSCore.Math.Sign@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Sign.double.png",
+      "contextData": "DSCore.Math.Sign@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Sign",
-      "iconName": "DSCore.Math.Sign.int",
-      "creationName": "DSCore.Math.Sign@int",
+      "iconName": "/src/resources/icons/DSCore.Math.Sign.int.png",
+      "contextData": "DSCore.Math.Sign@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Sin",
-      "iconName": "DSCore.Math.Sin",
-      "creationName": "DSCore.Math.Sin@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Sin.png",
+      "contextData": "DSCore.Math.Sin@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Sinh",
-      "iconName": "DSCore.Math.Sinh",
-      "creationName": "DSCore.Math.Sinh@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Sinh.png",
+      "contextData": "DSCore.Math.Sinh@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Sqrt",
-      "iconName": "DSCore.Math.Sqrt",
-      "creationName": "DSCore.Math.Sqrt@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Sqrt.png",
+      "contextData": "DSCore.Math.Sqrt@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Tan",
-      "iconName": "DSCore.Math.Tan",
-      "creationName": "DSCore.Math.Tan@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Tan.png",
+      "contextData": "DSCore.Math.Tan@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Tanh",
-      "iconName": "DSCore.Math.Tanh",
-      "creationName": "DSCore.Math.Tanh@double",
+      "iconName": "/src/resources/icons/DSCore.Math.Tanh.png",
+      "contextData": "DSCore.Math.Tanh@double",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Sum",
-      "iconName": "DSCore.Math.Sum",
-      "creationName": "DSCore.Math.Sum@double[]",
+      "iconName": "/src/resources/icons/DSCore.Math.Sum.png",
+      "contextData": "DSCore.Math.Sum@double[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Math.Factorial",
-      "iconName": "DSCore.Math.Factorial",
-      "creationName": "DSCore.Math.Factorial@int",
+      "iconName": "/src/resources/icons/DSCore.Math.Factorial.png",
+      "contextData": "DSCore.Math.Factorial@int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Object.IsNull",
-      "iconName": "DSCore.Object.IsNull",
-      "creationName": "DSCore.Object.IsNull@var",
+      "iconName": "/src/resources/icons/DSCore.Object.IsNull.png",
+      "contextData": "DSCore.Object.IsNull@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Object.Identity",
-      "iconName": "DSCore.Object.Identity",
-      "creationName": "DSCore.Object.Identity@var",
+      "iconName": "/src/resources/icons/DSCore.Object.Identity.png",
+      "contextData": "DSCore.Object.Identity@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Object.Type",
-      "iconName": "DSCore.Object.Type",
-      "creationName": "DSCore.Object.Type@var",
+      "iconName": "/src/resources/icons/DSCore.Object.Type.png",
+      "contextData": "DSCore.Object.Type@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.ToNumber",
-      "iconName": "DSCore.String.ToNumber",
-      "creationName": "DSCore.String.ToNumber@string",
+      "iconName": "/src/resources/icons/DSCore.String.ToNumber.png",
+      "contextData": "DSCore.String.ToNumber@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Concat",
-      "iconName": "DSCore.String.Concat",
-      "creationName": "DSCore.String.Concat@string[]",
+      "iconName": "/src/resources/icons/DSCore.String.Concat.png",
+      "contextData": "DSCore.String.Concat@string[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Length",
-      "iconName": "DSCore.String.Length",
-      "creationName": "DSCore.String.Length@string",
+      "iconName": "/src/resources/icons/DSCore.String.Length.png",
+      "contextData": "DSCore.String.Length@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Split",
-      "iconName": "DSCore.String.Split",
-      "creationName": "DSCore.String.Split@string,string[]",
+      "iconName": "/src/resources/icons/DSCore.String.Split.png",
+      "contextData": "DSCore.String.Split@string,string[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Join",
-      "iconName": "DSCore.String.Join",
-      "creationName": "DSCore.String.Join@string,string[]",
+      "iconName": "/src/resources/icons/DSCore.String.Join.png",
+      "contextData": "DSCore.String.Join@string,string[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.ToUpper",
-      "iconName": "DSCore.String.ToUpper",
-      "creationName": "DSCore.String.ToUpper@string",
+      "iconName": "/src/resources/icons/DSCore.String.ToUpper.png",
+      "contextData": "DSCore.String.ToUpper@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.ToLower",
-      "iconName": "DSCore.String.ToLower",
-      "creationName": "DSCore.String.ToLower@string",
+      "iconName": "/src/resources/icons/DSCore.String.ToLower.png",
+      "contextData": "DSCore.String.ToLower@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.ChangeCase",
-      "iconName": "DSCore.String.ChangeCase",
-      "creationName": "DSCore.String.ChangeCase@string,bool",
+      "iconName": "/src/resources/icons/DSCore.String.ChangeCase.png",
+      "contextData": "DSCore.String.ChangeCase@string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Substring",
-      "iconName": "DSCore.String.Substring",
-      "creationName": "DSCore.String.Substring@string,int,int",
+      "iconName": "/src/resources/icons/DSCore.String.Substring.png",
+      "contextData": "DSCore.String.Substring@string,int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Contains",
-      "iconName": "DSCore.String.Contains",
-      "creationName": "DSCore.String.Contains@string,string,bool",
+      "iconName": "/src/resources/icons/DSCore.String.Contains.png",
+      "contextData": "DSCore.String.Contains@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.CountOccurrences",
-      "iconName": "DSCore.String.CountOccurrences",
-      "creationName": "DSCore.String.CountOccurrences@string,string,bool",
+      "iconName": "/src/resources/icons/DSCore.String.CountOccurrences.png",
+      "contextData": "DSCore.String.CountOccurrences@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Replace",
-      "iconName": "DSCore.String.Replace",
-      "creationName": "DSCore.String.Replace@string,string,string",
+      "iconName": "/src/resources/icons/DSCore.String.Replace.png",
+      "contextData": "DSCore.String.Replace@string,string,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.EndsWith",
-      "iconName": "DSCore.String.EndsWith",
-      "creationName": "DSCore.String.EndsWith@string,string,bool",
+      "iconName": "/src/resources/icons/DSCore.String.EndsWith.png",
+      "contextData": "DSCore.String.EndsWith@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.StartsWith",
-      "iconName": "DSCore.String.StartsWith",
-      "creationName": "DSCore.String.StartsWith@string,string,bool",
+      "iconName": "/src/resources/icons/DSCore.String.StartsWith.png",
+      "contextData": "DSCore.String.StartsWith@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.TrimWhitespace",
-      "iconName": "DSCore.String.TrimWhitespace",
-      "creationName": "DSCore.String.TrimWhitespace@string",
+      "iconName": "/src/resources/icons/DSCore.String.TrimWhitespace.png",
+      "contextData": "DSCore.String.TrimWhitespace@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.TrimLeadingWhitespace",
-      "iconName": "DSCore.String.TrimLeadingWhitespace",
-      "creationName": "DSCore.String.TrimLeadingWhitespace@string",
+      "iconName": "/src/resources/icons/DSCore.String.TrimLeadingWhitespace.png",
+      "contextData": "DSCore.String.TrimLeadingWhitespace@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.TrimTrailingWhitespace",
-      "iconName": "DSCore.String.TrimTrailingWhitespace",
-      "creationName": "DSCore.String.TrimTrailingWhitespace@string",
+      "iconName": "/src/resources/icons/DSCore.String.TrimTrailingWhitespace.png",
+      "contextData": "DSCore.String.TrimTrailingWhitespace@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.IndexOf",
-      "iconName": "DSCore.String.IndexOf",
-      "creationName": "DSCore.String.IndexOf@string,string,bool",
+      "iconName": "/src/resources/icons/DSCore.String.IndexOf.png",
+      "contextData": "DSCore.String.IndexOf@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.AllIndicesOf",
-      "iconName": "DSCore.String.AllIndicesOf",
-      "creationName": "DSCore.String.AllIndicesOf@string,string,bool",
+      "iconName": "/src/resources/icons/DSCore.String.AllIndicesOf.png",
+      "contextData": "DSCore.String.AllIndicesOf@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.LastIndexOf",
-      "iconName": "DSCore.String.LastIndexOf",
-      "creationName": "DSCore.String.LastIndexOf@string,string,bool",
+      "iconName": "/src/resources/icons/DSCore.String.LastIndexOf.png",
+      "contextData": "DSCore.String.LastIndexOf@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.PadLeft",
-      "iconName": "DSCore.String.PadLeft",
-      "creationName": "DSCore.String.PadLeft@string,int,string",
+      "iconName": "/src/resources/icons/DSCore.String.PadLeft.png",
+      "contextData": "DSCore.String.PadLeft@string,int,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.PadRight",
-      "iconName": "DSCore.String.PadRight",
-      "creationName": "DSCore.String.PadRight@string,int,string",
+      "iconName": "/src/resources/icons/DSCore.String.PadRight.png",
+      "contextData": "DSCore.String.PadRight@string,int,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Center",
-      "iconName": "DSCore.String.Center",
-      "creationName": "DSCore.String.Center@string,int,string",
+      "iconName": "/src/resources/icons/DSCore.String.Center.png",
+      "contextData": "DSCore.String.Center@string,int,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Insert",
-      "iconName": "DSCore.String.Insert",
-      "creationName": "DSCore.String.Insert@string,int,string",
+      "iconName": "/src/resources/icons/DSCore.String.Insert.png",
+      "contextData": "DSCore.String.Insert@string,int,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.String.Remove",
-      "iconName": "DSCore.String.Remove",
-      "creationName": "DSCore.String.Remove@string,int,int",
+      "iconName": "/src/resources/icons/DSCore.String.Remove.png",
+      "contextData": "DSCore.String.Remove@string,int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.Thread.Pause",
-      "iconName": "DSCore.Thread.Pause",
-      "creationName": "DSCore.Thread.Pause@var,int",
+      "iconName": "/src/resources/icons/DSCore.Thread.Pause.png",
+      "contextData": "DSCore.Thread.Pause@var,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.FilePath.Combine",
-      "iconName": "DSCore.IO.FilePath.Combine",
-      "creationName": "DSCore.IO.FilePath.Combine@string[]",
+      "iconName": "/src/resources/icons/DSCore.IO.FilePath.Combine.png",
+      "contextData": "DSCore.IO.FilePath.Combine@string[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.FilePath.Extension",
-      "iconName": "DSCore.IO.FilePath.Extension",
-      "creationName": "DSCore.IO.FilePath.Extension@string",
+      "iconName": "/src/resources/icons/DSCore.IO.FilePath.Extension.png",
+      "contextData": "DSCore.IO.FilePath.Extension@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.FilePath.ChangeExtension",
-      "iconName": "DSCore.IO.FilePath.ChangeExtension",
-      "creationName": "DSCore.IO.FilePath.ChangeExtension@string,string",
+      "iconName": "/src/resources/icons/DSCore.IO.FilePath.ChangeExtension.png",
+      "contextData": "DSCore.IO.FilePath.ChangeExtension@string,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.FilePath.DirectoryName",
-      "iconName": "DSCore.IO.FilePath.DirectoryName",
-      "creationName": "DSCore.IO.FilePath.DirectoryName@string",
+      "iconName": "/src/resources/icons/DSCore.IO.FilePath.DirectoryName.png",
+      "contextData": "DSCore.IO.FilePath.DirectoryName@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.FilePath.FileName",
-      "iconName": "DSCore.IO.FilePath.FileName",
-      "creationName": "DSCore.IO.FilePath.FileName@string,bool",
+      "iconName": "/src/resources/icons/DSCore.IO.FilePath.FileName.png",
+      "contextData": "DSCore.IO.FilePath.FileName@string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.FilePath.HasExtension",
-      "iconName": "DSCore.IO.FilePath.HasExtension",
-      "creationName": "DSCore.IO.FilePath.HasExtension@string",
+      "iconName": "/src/resources/icons/DSCore.IO.FilePath.HasExtension.png",
+      "contextData": "DSCore.IO.FilePath.HasExtension@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.File.ReadText",
-      "iconName": "DSCore.IO.File.ReadText.var",
-      "creationName": "DSCore.IO.File.ReadText@var",
+      "iconName": "/src/resources/icons/DSCore.IO.File.ReadText.var.png",
+      "contextData": "DSCore.IO.File.ReadText@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.File.Move",
-      "iconName": "DSCore.IO.File.Move",
-      "creationName": "DSCore.IO.File.Move@string,string,bool",
+      "iconName": "/src/resources/icons/DSCore.IO.File.Move.png",
+      "contextData": "DSCore.IO.File.Move@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.File.Delete",
-      "iconName": "DSCore.IO.File.Delete",
-      "creationName": "DSCore.IO.File.Delete@string",
+      "iconName": "/src/resources/icons/DSCore.IO.File.Delete.png",
+      "contextData": "DSCore.IO.File.Delete@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.File.Copy",
-      "iconName": "DSCore.IO.File.Copy",
-      "creationName": "DSCore.IO.File.Copy@var,string,bool",
+      "iconName": "/src/resources/icons/DSCore.IO.File.Copy.png",
+      "contextData": "DSCore.IO.File.Copy@var,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.File.Exists",
-      "iconName": "DSCore.IO.File.Exists",
-      "creationName": "DSCore.IO.File.Exists@string",
+      "iconName": "/src/resources/icons/DSCore.IO.File.Exists.png",
+      "contextData": "DSCore.IO.File.Exists@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.File.WriteText",
-      "iconName": "DSCore.IO.File.WriteText",
-      "creationName": "DSCore.IO.File.WriteText@string,string",
+      "iconName": "/src/resources/icons/DSCore.IO.File.WriteText.png",
+      "contextData": "DSCore.IO.File.WriteText@string,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Directory.Move",
-      "iconName": "DSCore.IO.Directory.Move",
-      "creationName": "DSCore.IO.Directory.Move@string,string,bool",
+      "iconName": "/src/resources/icons/DSCore.IO.Directory.Move.png",
+      "contextData": "DSCore.IO.Directory.Move@string,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Directory.Copy",
-      "iconName": "DSCore.IO.Directory.Copy",
-      "creationName": "DSCore.IO.Directory.Copy@var,string,bool",
+      "iconName": "/src/resources/icons/DSCore.IO.Directory.Copy.png",
+      "contextData": "DSCore.IO.Directory.Copy@var,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Directory.Delete",
-      "iconName": "DSCore.IO.Directory.Delete",
-      "creationName": "DSCore.IO.Directory.Delete@string,bool",
+      "iconName": "/src/resources/icons/DSCore.IO.Directory.Delete.png",
+      "contextData": "DSCore.IO.Directory.Delete@string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Directory.Contents",
-      "iconName": "DSCore.IO.Directory.Contents",
-      "creationName": "DSCore.IO.Directory.Contents@var,string",
+      "iconName": "/src/resources/icons/DSCore.IO.Directory.Contents.png",
+      "contextData": "DSCore.IO.Directory.Contents@var,string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Directory.Exists",
-      "iconName": "DSCore.IO.Directory.Exists",
-      "creationName": "DSCore.IO.Directory.Exists@string",
+      "iconName": "/src/resources/icons/DSCore.IO.Directory.Exists.png",
+      "contextData": "DSCore.IO.Directory.Exists@string",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Image.ReadFromFile",
-      "iconName": "DSCore.IO.Image.ReadFromFile",
-      "creationName": "DSCore.IO.Image.ReadFromFile@var",
+      "iconName": "/src/resources/icons/DSCore.IO.Image.ReadFromFile.png",
+      "contextData": "DSCore.IO.Image.ReadFromFile@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Image.Pixels",
-      "iconName": "DSCore.IO.Image.Pixels",
-      "creationName": "DSCore.IO.Image.Pixels@var,int,int",
+      "iconName": "/src/resources/icons/DSCore.IO.Image.Pixels.png",
+      "contextData": "DSCore.IO.Image.Pixels@var,int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Image.FromPixels",
-      "iconName": "DSCore.IO.Image.FromPixels.Color2",
-      "creationName": "DSCore.IO.Image.FromPixels@DSCore.Color[][]",
+      "iconName": "/src/resources/icons/DSCore.IO.Image.FromPixels.Color2.png",
+      "contextData": "DSCore.IO.Image.FromPixels@DSCore.Color[][]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Image.FromPixels",
-      "iconName": "DSCore.IO.Image.FromPixels.Color1-int-int",
-      "creationName": "DSCore.IO.Image.FromPixels@DSCore.Color[],int,int",
+      "iconName": "/src/resources/icons/DSCore.IO.Image.FromPixels.Color1-int-int.png",
+      "contextData": "DSCore.IO.Image.FromPixels@DSCore.Color[],int,int",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Image.Dimensions",
-      "iconName": "DSCore.IO.Image.Dimensions",
-      "creationName": "DSCore.IO.Image.Dimensions@var",
+      "iconName": "/src/resources/icons/DSCore.IO.Image.Dimensions.png",
+      "contextData": "DSCore.IO.Image.Dimensions@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.Image.WriteToFile",
-      "iconName": "DSCore.IO.Image.WriteToFile",
-      "creationName": "DSCore.IO.Image.WriteToFile@string,var",
+      "iconName": "/src/resources/icons/DSCore.IO.Image.WriteToFile.png",
+      "contextData": "DSCore.IO.Image.WriteToFile@string,var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.CSV.WriteToFile",
-      "iconName": "DSCore.IO.CSV.WriteToFile",
-      "creationName": "DSCore.IO.CSV.WriteToFile@string,var[][]",
+      "iconName": "/src/resources/icons/DSCore.IO.CSV.WriteToFile.png",
+      "contextData": "DSCore.IO.CSV.WriteToFile@string,var[][]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSCore.IO.CSV.ReadFromFile",
-      "iconName": "DSCore.IO.CSV.ReadFromFile",
-      "creationName": "DSCore.IO.CSV.ReadFromFile@var",
+      "iconName": "/src/resources/icons/DSCore.IO.CSV.ReadFromFile.png",
+      "contextData": "DSCore.IO.CSV.ReadFromFile@var",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSOffice.Excel.ReadFromFile",
-      "iconName": "DSOffice.Excel.ReadFromFile",
-      "creationName": "DSOffice.Excel.ReadFromFile@var,string,bool",
+      "iconName": "/src/resources/icons/DSOffice.Excel.ReadFromFile.png",
+      "contextData": "DSOffice.Excel.ReadFromFile@var,string,bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DSOffice.Excel.WriteToFile",
-      "iconName": "DSOffice.Excel.WriteToFile",
-      "creationName": "DSOffice.Excel.WriteToFile@string,string,int,int,var[][],bool",
+      "iconName": "/src/resources/icons/DSOffice.Excel.WriteToFile.png",
+      "contextData": "DSOffice.Excel.WriteToFile@string,string,int,int,var[][],bool",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "DynamoUnits.Location.Name",
-      "iconName": "DynamoUnits.Location.Name",
-      "creationName": "DynamoUnits.Location.Name",
+      "iconName": "/src/resources/icons/DynamoUnits.Location.Name.png",
+      "contextData": "DynamoUnits.Location.Name",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DynamoUnits.Location.Latitude",
-      "iconName": "DynamoUnits.Location.Latitude",
-      "creationName": "DynamoUnits.Location.Latitude",
+      "iconName": "/src/resources/icons/DynamoUnits.Location.Latitude.png",
+      "contextData": "DynamoUnits.Location.Latitude",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DynamoUnits.Location.Longitude",
-      "iconName": "DynamoUnits.Location.Longitude",
-      "creationName": "DynamoUnits.Location.Longitude",
+      "iconName": "/src/resources/icons/DynamoUnits.Location.Longitude.png",
+      "contextData": "DynamoUnits.Location.Longitude",
       "itemType": "query"
     },
     {
       "fullyQualifiedName": "DynamoUnits.Location.ByLatitudeAndLongitude",
-      "iconName": "DynamoUnits.Location.ByLatitudeAndLongitude",
-      "creationName": "DynamoUnits.Location.ByLatitudeAndLongitude@double,double,string",
+      "iconName": "/src/resources/icons/DynamoUnits.Location.ByLatitudeAndLongitude.png",
+      "contextData": "DynamoUnits.Location.ByLatitudeAndLongitude@double,double,string",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Tessellation.ConvexHull.ByPoints",
-      "iconName": "Tessellation.ConvexHull.ByPoints",
-      "creationName": "Tessellation.ConvexHull.ByPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Tessellation.ConvexHull.ByPoints.png",
+      "contextData": "Tessellation.ConvexHull.ByPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Tessellation.Delaunay.ByParametersOnSurface",
-      "iconName": "Tessellation.Delaunay.ByParametersOnSurface",
-      "creationName": "Tessellation.Delaunay.ByParametersOnSurface@Autodesk.DesignScript.Geometry.UV[],Autodesk.DesignScript.Geometry.Surface",
+      "iconName": "/src/resources/icons/Tessellation.Delaunay.ByParametersOnSurface.png",
+      "contextData": "Tessellation.Delaunay.ByParametersOnSurface@Autodesk.DesignScript.Geometry.UV[],Autodesk.DesignScript.Geometry.Surface",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Tessellation.Delaunay.ByPoints",
-      "iconName": "Tessellation.Delaunay.ByPoints",
-      "creationName": "Tessellation.Delaunay.ByPoints@Autodesk.DesignScript.Geometry.Point[]",
+      "iconName": "/src/resources/icons/Tessellation.Delaunay.ByPoints.png",
+      "contextData": "Tessellation.Delaunay.ByPoints@Autodesk.DesignScript.Geometry.Point[]",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Tessellation.Voronoi.ByParametersOnSurface",
-      "iconName": "Tessellation.Voronoi.ByParametersOnSurface",
-      "creationName": "Tessellation.Voronoi.ByParametersOnSurface@Autodesk.DesignScript.Geometry.UV[],Autodesk.DesignScript.Geometry.Surface",
+      "iconName": "/src/resources/icons/Tessellation.Voronoi.ByParametersOnSurface.png",
+      "contextData": "Tessellation.Voronoi.ByParametersOnSurface@Autodesk.DesignScript.Geometry.UV[],Autodesk.DesignScript.Geometry.Surface",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Analysis.Label.ByPointAndString",
-      "iconName": "Analysis.Label.ByPointAndString",
-      "creationName": "Analysis.Label.ByPointAndString@Autodesk.DesignScript.Geometry.Point,string",
+      "iconName": "/src/resources/icons/Analysis.Label.ByPointAndString.png",
+      "contextData": "Analysis.Label.ByPointAndString@Autodesk.DesignScript.Geometry.Point,string",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Analysis.AnalysisExtensions.IsAlmostEqualTo",
-      "iconName": "Analysis.AnalysisExtensions.IsAlmostEqualTo",
-      "creationName": "Analysis.AnalysisExtensions.IsAlmostEqualTo@Autodesk.DesignScript.Geometry.UV,Autodesk.DesignScript.Geometry.UV",
+      "iconName": "/src/resources/icons/Analysis.AnalysisExtensions.IsAlmostEqualTo.png",
+      "contextData": "Analysis.AnalysisExtensions.IsAlmostEqualTo@Autodesk.DesignScript.Geometry.UV,Autodesk.DesignScript.Geometry.UV",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Display.Display.ByGeometryColor",
-      "iconName": "Display.Display.ByGeometryColor",
-      "creationName": "Display.Display.ByGeometryColor@Autodesk.DesignScript.Geometry.Geometry,DSCore.Color",
+      "iconName": "/src/resources/icons/Display.Display.ByGeometryColor.png",
+      "contextData": "Display.Display.ByGeometryColor@Autodesk.DesignScript.Geometry.Geometry,DSCore.Color",
       "itemType": "creation"
     },
     {
       "fullyQualifiedName": "Display.Display.BySurfaceColors",
-      "iconName": "Display.Display.BySurfaceColors",
-      "creationName": "Display.Display.BySurfaceColors@Autodesk.DesignScript.Geometry.Surface,DSCore.Color[][]",
+      "iconName": "/src/resources/icons/Display.Display.BySurfaceColors.png",
+      "contextData": "Display.Display.BySurfaceColors@Autodesk.DesignScript.Geometry.Surface,DSCore.Color[][]",
       "itemType": "creation"
-    },
-    {
-      "fullyQualifiedName": "Dynamo.Trial",
-      "iconName": "d4761072-948d-4a3b-b55b-d6c2aef2e60f",
-      "creationName": "Trial",
-      "itemType": "action"
     }
   ]
 }

--- a/docs/v0.0.1/layout-specs.md
+++ b/docs/v0.0.1/layout-specs.md
@@ -9,7 +9,7 @@ The following example illustrates the simplest form of a specification `json` do
   "elements": [
     {
       "text": "Display",
-      "iconName": "Category.Display.svg",
+      "iconUrl": "Category.Display.svg",
       "elementType": "category",
       "include": [],
       "childElements": []
@@ -25,7 +25,7 @@ This results in library view that looks like the following image:
 Each element in the hierarchical structure contains the following key-value pairs:
 
 - `text` - the content to display on the corresponding library item
-- `iconName` - file name of the icon for the corresponding library item
+- `iconUrl` - absolute URL of the icon for the corresponding library item
 - `elementType` - the type of the element. Possible values are *category*, *group*, *creation*, *action*, *query* and *none*. See the following section for detailed descriptions of each element types
 - `include` - data types that should be included under this given library item (more details on this later)
 - `childElements` - nested elements under this element (its usage will become clearer below)
@@ -49,7 +49,7 @@ Data types can be added to a given element by adding them as values to `include`
   "elements": [
     {
       "text": "Display",
-      "iconName": "Category.Display.svg",
+      "iconUrl": "Category.Display.svg",
       "elementType": "category",
       "include": [
         { "path": "DSCore.Color" },
@@ -65,14 +65,14 @@ This results in library view that looks like the following image:
 ![image](img/layout-include.png?raw=true)
 
 ### Adding nested elements
-Adding on to the previous example, a nested element with text `Watch` is added under `Display` element. Just like the parent element, nested elements contain keys like `text`, `iconName`, etc. Note that however, the nested element does not have to contain `childElements` if it does not need to:
+Adding on to the previous example, a nested element with text `Watch` is added under `Display` element. Just like the parent element, nested elements contain keys like `text`, `iconUrl`, etc. Note that however, the nested element does not have to contain `childElements` if it does not need to:
 
 ```json
 {
   "elements": [
     {
       "text": "Display",
-      "iconName": "Category.Display.svg",
+      "iconUrl": "Category.Display.svg",
       "elementType": "category",
       "include": [
         { "path": "DSCore.Color" },
@@ -81,7 +81,7 @@ Adding on to the previous example, a nested element with text `Watch` is added u
       "childElements": [
         {
           "text": "Watch",
-          "iconName": "Watch",
+          "iconUrl": "Watch",
           "elementType": "none",
           "include": []
         }        
@@ -102,7 +102,7 @@ The following example adds three new data types under `Watch` element:
   "elements": [
     {
       "text": "Display",
-      "iconName": "Category.Display.svg",
+      "iconUrl": "Category.Display.svg",
       "elementType": "category",
       "include": [
         { "path": "DSCore.Color" },
@@ -111,7 +111,7 @@ The following example adds three new data types under `Watch` element:
       "childElements": [
         {
           "text": "Watch",
-          "iconName": "Watch",
+          "iconUrl": "Watch",
           "elementType": "none",
           "include": [
             { "path": "Core.View.Watch" },

--- a/docs/v0.0.1/loaded-data-types.md
+++ b/docs/v0.0.1/loaded-data-types.md
@@ -6,9 +6,9 @@ This flat list of loaded data types takes the following form: it must contain ex
 
 - `fullyQualifiedName` - Fully qualified name of a given type (e.g. a method or property in a class). An example of this would be `Autodesk.DesignScript.Geometry.Curve.Offset` property. The fully qualified name is used for inclusion/exclusion under a given branch of the library after transformation (transformation is done through a [Layout Specification](./layout-specs.md) document).
 
-- `iconName` - Icon name of a given type. This can optionally include `*.svg` extension; if it does not contain `*.svg` extension, then a `.png` is appended to the icon name by default. **Note**: absolute URL of icon is not currently supported yet.
+- `iconUrl` - Absolute URL of icon of a given type.
 
-- `creationName` - The string value that will be passed to the event handler when a given library item is clicked.
+- `contextData` - The string value that will be passed to the event handler when a given library item is clicked.
 
 - `itemType` - This value can either be `creation`, `action` or `query`. For more details of these values, please refer to [Layout Specification](./layout-specs.md) document.
 
@@ -19,14 +19,14 @@ This flat list of loaded data types takes the following form: it must contain ex
   "loadedTypes": [
     {
       "fullyQualifiedName": "Core.Input.Code Block",
-      "iconName": "Dynamo.Graph.Nodes.CodeBlockNodeModel",
-      "creationName": "Code Block",
+      "iconUrl": "Dynamo.Graph.Nodes.CodeBlockNodeModel",
+      "contextData": "Code Block",
       "itemType": "action"
     },
     {
       "fullyQualifiedName": "Core.Input.Input",
-      "iconName": "Dynamo.Graph.Nodes.CustomNodes.Symbol",
-      "creationName": "Input",
+      "iconUrl": "Dynamo.Graph.Nodes.CustomNodes.Symbol",
+      "contextData": "Input",
       "itemType": "action"
     },
 

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -58,7 +58,7 @@ export class ItemData {
     }
 
     constructFromLayoutElement(layoutElement: LayoutElement) {
-        this.creationName = layoutElement.text;
+        this.text = layoutElement.text;
         this.iconName = layoutElement.iconName;
         this.itemType = layoutElement.elementType;
     }

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -105,13 +105,7 @@ export function constructNestedLibraryItems(
     for (let i = startIndex; i < fullNameParts.length; i++) {
         let libraryItem = new ItemData(fullNameParts[i]);
         libraryItem.itemType = "none";
-
-        // If 'i' is now '2' (i.e. it points to 'C'), then we will construct 
-        // the iconUrl as 'A.B.C'. And since the second parameter of 'slice' 
-        // is exclusive, we add '1' to it otherwise 'C' won't be included.
-        //  
-        libraryItem.iconUrl = fullNameParts.slice(0, i + 1).join(".");
-        if (iconUrl) libraryItem.iconUrl = iconUrl; // If there is a iconUrl specified, assign to iconUrl
+        libraryItem.iconUrl = iconUrl; 
 
         // If this is the leaf most level, copy all item information over.
         if (i == fullNameParts.length - 1) {

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -12,13 +12,14 @@ export class TypeListNode {
     constructor(data: any) {
         this.fullyQualifiedName = data.fullyQualifiedName;
         this.iconName = data.iconName;
-        this.creationName = data.creationName;
+        this.creationName = data.contextData;
         this.memberType = data.itemType;
     }
 }
 
 export interface IncludeInfo {
     path: string;
+    pathIcon?: string;
     inclusive?: boolean;
 }
 
@@ -57,7 +58,7 @@ export class ItemData {
     }
 
     constructFromLayoutElement(layoutElement: LayoutElement) {
-        this.text = layoutElement.text;
+        this.creationName = layoutElement.text;
         this.iconName = layoutElement.iconName;
         this.itemType = layoutElement.elementType;
     }
@@ -71,7 +72,8 @@ export function constructNestedLibraryItems(
     includeParts: string[],
     typeListNode: TypeListNode,
     inclusive: boolean,
-    parentItem: ItemData): ItemData {
+    parentItem: ItemData,
+    pathIcon?: string): ItemData {
     // 'includeParts' is always lesser or equal to 'fullNameParts' in length.
     // 
     // Take an example:
@@ -109,6 +111,7 @@ export function constructNestedLibraryItems(
         // is exclusive, we add '1' to it otherwise 'C' won't be included.
         //  
         libraryItem.iconName = fullNameParts.slice(0, i + 1).join(".");
+        if (pathIcon) libraryItem.iconName = pathIcon; // If there is a pathIcon specified, assign to iconName
 
         // If this is the leaf most level, copy all item information over.
         if (i == fullNameParts.length - 1) {
@@ -181,7 +184,7 @@ export function constructLibraryItem(
             }
 
             parentNode = constructNestedLibraryItems(includeParts,
-                typeListNodes[j], inclusive, parentNode);
+                typeListNodes[j], inclusive, parentNode, layoutElement.include[i].pathIcon);
         }
 
         if (parentNode && (parentNode != result)) {

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -5,35 +5,35 @@ type ItemType = "none" | "category" | "group" | "creation" | "action" | "query";
 export class TypeListNode {
 
     fullyQualifiedName: string = "";
-    iconName: string = "";
-    creationName: string = "";
+    iconUrl: string = "";
+    contextData: string = "";
     memberType: MemberType = "none";
 
     constructor(data: any) {
         this.fullyQualifiedName = data.fullyQualifiedName;
-        this.iconName = data.iconName;
-        this.creationName = data.contextData;
+        this.iconUrl = data.iconUrl;
+        this.contextData = data.contextData;
         this.memberType = data.itemType;
     }
 }
 
 export interface IncludeInfo {
     path: string;
-    pathIcon?: string;
+    iconUrl?: string;
     inclusive?: boolean;
 }
 
 export class LayoutElement {
 
     text: string = "";
-    iconName: string = "";
+    iconUrl: string = "";
     elementType: ElementType = "none";
     include: IncludeInfo[] = [];
     childElements: LayoutElement[] = [];
 
     constructor(data: any) {
         this.text = data.text;
-        this.iconName = data.iconName;
+        this.iconUrl = data.iconUrl;
         this.elementType = data.elementType;
         this.include = data.include;
         if (data.childElements) {
@@ -49,8 +49,8 @@ export class LayoutElement {
 
 export class ItemData {
 
-    iconName: string = "";
-    creationName: string = "";
+    iconUrl: string = "";
+    contextData: string = "";
     itemType: ItemType = "none";
     childItems: ItemData[] = [];
 
@@ -58,8 +58,8 @@ export class ItemData {
     }
 
     constructFromLayoutElement(layoutElement: LayoutElement) {
-        this.creationName = layoutElement.text;
-        this.iconName = layoutElement.iconName;
+        this.contextData = layoutElement.text;
+        this.iconUrl = layoutElement.iconUrl;
         this.itemType = layoutElement.elementType;
     }
 
@@ -73,7 +73,7 @@ export function constructNestedLibraryItems(
     typeListNode: TypeListNode,
     inclusive: boolean,
     parentItem: ItemData,
-    pathIcon?: string): ItemData {
+    iconUrl?: string): ItemData {
     // 'includeParts' is always lesser or equal to 'fullNameParts' in length.
     // 
     // Take an example:
@@ -107,16 +107,16 @@ export function constructNestedLibraryItems(
         libraryItem.itemType = "none";
 
         // If 'i' is now '2' (i.e. it points to 'C'), then we will construct 
-        // the iconName as 'A.B.C'. And since the second parameter of 'slice' 
+        // the iconUrl as 'A.B.C'. And since the second parameter of 'slice' 
         // is exclusive, we add '1' to it otherwise 'C' won't be included.
         //  
-        libraryItem.iconName = fullNameParts.slice(0, i + 1).join(".");
-        if (pathIcon) libraryItem.iconName = pathIcon; // If there is a pathIcon specified, assign to iconName
+        libraryItem.iconUrl = fullNameParts.slice(0, i + 1).join(".");
+        if (iconUrl) libraryItem.iconUrl = iconUrl; // If there is a iconUrl specified, assign to iconUrl
 
         // If this is the leaf most level, copy all item information over.
         if (i == fullNameParts.length - 1) {
-            libraryItem.creationName = typeListNode.creationName;
-            libraryItem.iconName = typeListNode.iconName;
+            libraryItem.contextData = typeListNode.contextData;
+            libraryItem.iconUrl = typeListNode.iconUrl;
             libraryItem.itemType = typeListNode.memberType;
         }
 
@@ -184,7 +184,7 @@ export function constructLibraryItem(
             }
 
             parentNode = constructNestedLibraryItems(includeParts,
-                typeListNodes[j], inclusive, parentNode, layoutElement.include[i].pathIcon);
+                typeListNodes[j], inclusive, parentNode, layoutElement.include[i].iconUrl);
         }
 
         if (parentNode && (parentNode != result)) {

--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -59,15 +59,12 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
 
     render() {
 
-        let iconPath = "/src/resources/icons/" + this.props.data.iconName;
-        if (!iconPath.endsWith(".svg")) { iconPath = iconPath + ".png"; }
-
         let iconElement = null;
         let libraryItemTextStyle = "LibraryItemGroupText";
 
         if (this.props.data.itemType != "group") { // Group displays only text without icon.
             libraryItemTextStyle = "LibraryItemText";
-            iconElement = (<img className={"LibraryItemIcon"} src={iconPath} />);
+            iconElement = (<img className={"LibraryItemIcon"} src={this.props.data.iconName} />);
         }
 
         let nestedElements = null;

--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -64,7 +64,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
 
         if (this.props.data.itemType != "group") { // Group displays only text without icon.
             libraryItemTextStyle = "LibraryItemText";
-            iconElement = (<img className={"LibraryItemIcon"} src={this.props.data.iconName} />);
+            iconElement = (<img className={"LibraryItemIcon"} src={this.props.data.iconUrl} />);
         }
 
         let nestedElements = null;
@@ -191,6 +191,6 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         this.setState({ expanded: !currentlyExpanded });
 
         let libraryView = this.props.libraryView;
-        libraryView.raiseEvent("itemClicked", this.props.data.creationName);
+        libraryView.raiseEvent("itemClicked", this.props.data.contextData);
     }
 }

--- a/test/libraryUtilitiesTest.ts
+++ b/test/libraryUtilitiesTest.ts
@@ -16,9 +16,9 @@ describe('listNode Class', function () {
     let emptyTypeListNode = new LibraryUtilities.TypeListNode(testData);
 
     expect(emptyTypeListNode.fullyQualifiedName).to.equal(undefined);
-    expect(emptyTypeListNode.iconName).to.equal(undefined);
+    expect(emptyTypeListNode.iconUrl).to.equal(undefined);
     expect(emptyTypeListNode.memberType).to.equal(undefined);
-    expect(emptyTypeListNode.creationName).to.equal(undefined);
+    expect(emptyTypeListNode.contextData).to.equal(undefined);
   });
 
   it('should create a TypeListNode with correct attributes', function () {
@@ -26,14 +26,14 @@ describe('listNode Class', function () {
     let none = 'none';
 
     testData.fullyQualifiedName = test;
-    testData.iconName = test;
-    testData.creationName = test;
+    testData.iconUrl = test;
+    testData.contextData = test;
     testData.itemType = none;
 
     let testTypeListNode = new LibraryUtilities.TypeListNode(testData);
     expect(testTypeListNode.fullyQualifiedName).to.equal(test);
-    expect(testTypeListNode.iconName).to.equal(test);
-    expect(testTypeListNode.creationName).to.equal(test);
+    expect(testTypeListNode.iconUrl).to.equal(test);
+    expect(testTypeListNode.contextData).to.equal(test);
     expect(testTypeListNode.memberType).to.equal(none);
   });
 });
@@ -50,7 +50,7 @@ describe("LayoutElement class", function () {
     let emptyLayoutElement = new LibraryUtilities.LayoutElement(testData);
 
     expect(emptyLayoutElement.text).to.equal(undefined);
-    expect(emptyLayoutElement.iconName).to.equal(undefined);
+    expect(emptyLayoutElement.iconUrl).to.equal(undefined);
     expect(emptyLayoutElement.elementType).to.equal(undefined);
     expect(emptyLayoutElement.include).to.equal(undefined);
     expect(emptyLayoutElement.childElements.length).to.equal(0);
@@ -89,8 +89,8 @@ describe('LibraryItem class', function () {
   it('should create an LibraryItem from string', function () {
     let testLibraryItem = new LibraryUtilities.ItemData(emptyString);
 
-    expect(testLibraryItem.iconName).to.equal(emptyString);
-    expect(testLibraryItem.creationName).to.equal(emptyString);
+    expect(testLibraryItem.iconUrl).to.equal(emptyString);
+    expect(testLibraryItem.contextData).to.equal(emptyString);
     expect(testLibraryItem.text).to.equal(emptyString);
     expect(testLibraryItem.itemType).to.equal('none');
     expect(testLibraryItem.childItems.length).to.equal(0);
@@ -100,8 +100,8 @@ describe('LibraryItem class', function () {
     let testLibraryItem = new LibraryUtilities.ItemData(emptyString);
     testLibraryItem.constructFromLayoutElement(testData);
 
-    expect(testLibraryItem.iconName).to.equal(undefined);
-    expect(testLibraryItem.creationName).to.equal(emptyString);
+    expect(testLibraryItem.iconUrl).to.equal(undefined);
+    expect(testLibraryItem.contextData).to.equal(emptyString);
     expect(testLibraryItem.text).to.equal(undefined);
     expect(testLibraryItem.itemType).to.equal(undefined);
     expect(testLibraryItem.childItems.length).to.equal(0);
@@ -164,13 +164,13 @@ describe('constructNestedLibraryItems function', function () {
     result = LibraryUtilities.constructNestedLibraryItems(includedParts, typeListNode, inclusive, parentItem);
 
     expect(result.text).to.equal('a');
-    expect(result.iconName).to.equal('a');
+    expect(result.iconUrl).to.equal('a');
     expect(result.itemType).to.equal('none');
     expect(result.childItems.length).to.equal(1);
 
     expect(result.childItems[0].text).to.equal('b');
-    expect(result.childItems[0].iconName).to.equal(typeListNode.iconName);
-    expect(result.childItems[0].creationName).to.equal(typeListNode.creationName);
+    expect(result.childItems[0].iconUrl).to.equal(typeListNode.iconUrl);
+    expect(result.childItems[0].contextData).to.equal(typeListNode.contextData);
     expect(result.childItems[0].itemType).to.equal(typeListNode.memberType);
   });
 
@@ -184,18 +184,18 @@ describe('constructNestedLibraryItems function', function () {
     result = LibraryUtilities.constructNestedLibraryItems(includedParts, typeListNode, inclusive, parentItem);
 
     expect(result.text).to.equal('a');
-    expect(result.iconName).to.equal('a');
+    expect(result.iconUrl).to.equal('a');
     expect(result.itemType).to.equal('none');
     expect(result.childItems.length).to.equal(1);
 
     expect(result.childItems[0].text).to.equal('b');
-    expect(result.childItems[0].iconName).to.equal('a.b');
+    expect(result.childItems[0].iconUrl).to.equal('a.b');
     expect(result.childItems[0].itemType).to.equal('none');
     expect(result.childItems[0].childItems.length).to.equal(1);
 
     expect(result.childItems[0].childItems[0].text).to.equal('c');
-    expect(result.childItems[0].childItems[0].iconName).to.equal(typeListNode.iconName);
-    expect(result.childItems[0].childItems[0].creationName).to.equal(typeListNode.creationName);
+    expect(result.childItems[0].childItems[0].iconUrl).to.equal(typeListNode.iconUrl);
+    expect(result.childItems[0].childItems[0].contextData).to.equal(typeListNode.contextData);
     expect(result.childItems[0].childItems[0].itemType).to.equal(typeListNode.memberType);
     expect(result.childItems[0].childItems[0].childItems.length).to.equal(0);
   });
@@ -210,14 +210,14 @@ describe('constructNestedLibraryItems function', function () {
     result = LibraryUtilities.constructNestedLibraryItems(includedParts, typeListNode, inclusive, parentItem);
 
     expect(result.text).to.equal(parentItem.text);
-    expect(result.iconName).to.equal(parentItem.iconName);
-    expect(result.creationName).to.equal(parentItem.creationName);
+    expect(result.iconUrl).to.equal(parentItem.iconUrl);
+    expect(result.contextData).to.equal(parentItem.contextData);
     expect(result.itemType).to.equal(parentItem.itemType);
     expect(result.childItems.length).to.equal(1);
 
     expect(result.childItems[0].text).to.equal('b');
-    expect(result.childItems[0].iconName).to.equal(typeListNode.iconName);
-    expect(result.childItems[0].creationName).to.equal(typeListNode.creationName);
+    expect(result.childItems[0].iconUrl).to.equal(typeListNode.iconUrl);
+    expect(result.childItems[0].contextData).to.equal(typeListNode.contextData);
     expect(result.childItems[0].itemType).to.equal(typeListNode.memberType);
   });
 
@@ -231,19 +231,19 @@ describe('constructNestedLibraryItems function', function () {
     result = LibraryUtilities.constructNestedLibraryItems(includedParts, typeListNode, inclusive, parentItem);
 
     expect(result.text).to.equal(parentItem.text);
-    expect(result.iconName).to.equal(parentItem.iconName);
-    expect(result.creationName).to.equal(parentItem.creationName);
+    expect(result.iconUrl).to.equal(parentItem.iconUrl);
+    expect(result.contextData).to.equal(parentItem.contextData);
     expect(result.itemType).to.equal(parentItem.itemType);
     expect(result.childItems.length).to.equal(1);
 
     expect(result.childItems[0].text).to.equal('b');
-    expect(result.childItems[0].iconName).to.equal('a.b');
+    expect(result.childItems[0].iconUrl).to.equal('a.b');
     expect(result.childItems[0].itemType).to.equal('none');
     expect(result.childItems[0].childItems.length).to.equal(1);
 
     expect(result.childItems[0].childItems[0].text).to.equal('c');
-    expect(result.childItems[0].childItems[0].iconName).to.equal(typeListNode.iconName);
-    expect(result.childItems[0].childItems[0].creationName).to.equal(typeListNode.creationName);
+    expect(result.childItems[0].childItems[0].iconUrl).to.equal(typeListNode.iconUrl);
+    expect(result.childItems[0].childItems[0].contextData).to.equal(typeListNode.contextData);
     expect(result.childItems[0].childItems[0].itemType).to.equal(typeListNode.memberType);
     expect(result.childItems[0].childItems[0].childItems.length).to.equal(0);
   });
@@ -271,7 +271,7 @@ describe('constructLibraryItem function', function () {
 
     expect(result).to.be.an.instanceOf(LibraryUtilities.ItemData);
     expect(result.text).to.equal(layoutElement.text);
-    expect(result.iconName).to.equal(layoutElement.iconName);
+    expect(result.iconUrl).to.equal(layoutElement.iconUrl);
     expect(result.itemType).to.equal(layoutElement.elementType);
     expect(result.childItems.length).to.equal(0);
   });
@@ -289,7 +289,7 @@ describe('constructLibraryItem function', function () {
     result = LibraryUtilities.constructLibraryItem(typeListNodes, layoutElement);
 
     expect(result.text).to.equal(layoutElement.text);
-    expect(result.iconName).to.equal(layoutElement.iconName);
+    expect(result.iconUrl).to.equal(layoutElement.iconUrl);
     expect(result.itemType).to.equal(layoutElement.elementType);
     expect(result.childItems.length).to.equal(0);
   });
@@ -307,13 +307,13 @@ describe('constructLibraryItem function', function () {
     result = LibraryUtilities.constructLibraryItem(typeListNodes, layoutElement);
 
     expect(result.text).to.equal(layoutElement.text);
-    expect(result.iconName).to.equal(layoutElement.iconName);
+    expect(result.iconUrl).to.equal(layoutElement.iconUrl);
     expect(result.itemType).to.equal(layoutElement.elementType);
     expect(result.childItems.length).to.equal(1);
 
     expect(result.childItems[0].text).to.equal(typeListNode.fullyQualifiedName);
-    expect(result.childItems[0].iconName).to.equal(typeListNode.iconName);
-    expect(result.childItems[0].creationName).to.equal(typeListNode.creationName);
+    expect(result.childItems[0].iconUrl).to.equal(typeListNode.iconUrl);
+    expect(result.childItems[0].contextData).to.equal(typeListNode.contextData);
     expect(result.childItems[0].itemType).to.equal(typeListNode.memberType);
     expect(result.childItems[0].childItems.length).to.equal(0);
   });

--- a/test/libraryUtilitiesTestClasses.ts
+++ b/test/libraryUtilitiesTestClasses.ts
@@ -1,14 +1,14 @@
 export class TypeListNodeData {
     fullyQualifiedName: any;
-    iconName: any;
-    creationName: any;
+    iconUrl: any;
+    contextData: any;
     itemType: any;
 }
 
 
 export class LayoutElementData {
     text: any;
-    iconName: any;
+    iconUrl: any;
     elementType: any;
     include: any;
     childElements: LayoutElementData[] = [];


### PR DESCRIPTION
This is to address [DYN-636](https://jira.autodesk.com/browse/DYN-636).
`creationName` is renamed to `contextData` in `RawTypeData.json`. Furthermore, `iconName`s are updated to include absolute urls of the icons.

Also, I was thinking if we could have a `pathIcon` property that specifies an icon for a `path` as well.

e.g.
```
...
"include": [
             {
              "path": "Autodesk.DesignScript.Geometry.BoundingBox",
              "pathIcon": "/src/resources/icons/Autodesk.DesignScript.Geometry.BoundingBox.png"
             },
...
```

Can render the icon for BoundingBox, and at the same time include the nodes which have `Autodesk.DesignScript.Geometry.BoundingBox` in their names:

![capture](https://cloud.githubusercontent.com/assets/17231814/24036902/ab951d54-0b36-11e7-869e-211f30f437d8.PNG)

This is for expandable library items whose element type is `none`. Thoughts?

@Benglin 