### PR TITLE
Bundle css/react/react-dom all into build

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 </head>
 
 <body>
-    <!-- Style sheets for library view  -->
-    <link rel="stylesheet" href="/src/resources/LibraryStyles.css" />
+     <!--Style sheets for library view  
+    <link rel="stylesheet" href="/src/resources/LibraryStyles.css" />-->
 
     <div id="libraryContainerPlaceholder"></div>
 
@@ -26,7 +26,7 @@
     <script src="./node_modules/react-dom/dist/react-dom.js"></script>
 
     <!-- The main library view compoment -->
-    <script src='./dist/v0.0.1/librarie.min.js'></script>
+    <script src='./dist/v0.0.1/librarie.js'></script>
 
     <script>
         let configuration = {

--- a/index.html
+++ b/index.html
@@ -16,17 +16,11 @@
 </head>
 
 <body>
-     <!--Style sheets for library view  
-    <link rel="stylesheet" href="/src/resources/LibraryStyles.css" />-->
 
     <div id="libraryContainerPlaceholder"></div>
 
-    <!-- Dependencies -->
-    <script src="./node_modules/react/dist/react.js"></script>
-    <script src="./node_modules/react-dom/dist/react-dom.js"></script>
-
     <!-- The main library view compoment -->
-    <script src='./dist/v0.0.1/librarie.js'></script>
+    <script src='./dist/v0.0.1/librarie.min.js'></script>
 
     <script>
         let configuration = {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 var fs = require("fs");
 var express = require("express");
 var app = express();

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+
 var fs = require("fs");
 var express = require("express");
 var app = express();

--- a/package.json
+++ b/package.json
@@ -30,8 +30,11 @@
     "@types/underscore": "^1.8.0",
     "awesome-typescript-loader": "^3.0.0-beta.18",
     "chai": "^3.5.0",
+    "css-loader": "^0.27.3",
+    "file-loader": "^0.10.1",
     "mocha": "^3.2.0",
     "source-map-loader": "^0.1.5",
+    "style-loader": "^0.15.0",
     "ts-node": "^2.1.0",
     "typescript": "^2.1.4",
     "webpack": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "mocha -r ts-node/register test/libraryUtilitiesTest.ts",
     "build": "npm run dev & npm run prod",
-    "dev": "cross-env production_build=0 webpack",
-    "prod": "cross-env production_build=1 webpack"
+    "dev": "cross-env NODE_ENV=development webpack",
+    "prod": "cross-env NODE_ENV=production webpack"
   },
   "keywords": [
     "Dynamo",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "mocha -r ts-node/register test/libraryUtilitiesTest.ts",
     "build": "npm run dev & npm run prod",
-    "dev": "set production_build=0 & webpack",
-    "prod": "set production_build=1 & webpack"
+    "dev": "cross-env production_build=0 webpack",
+    "prod": "cross-env production_build=1 webpack"
   },
   "keywords": [
     "Dynamo",
@@ -30,6 +30,7 @@
     "@types/underscore": "^1.8.0",
     "awesome-typescript-loader": "^3.0.0-beta.18",
     "chai": "^3.5.0",
+    "cross-env": "^3.2.4",
     "css-loader": "^0.27.3",
     "file-loader": "^0.10.1",
     "mocha": "^3.2.0",

--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -1,5 +1,7 @@
 /// <reference path="../../node_modules/@types/node/index.d.ts" />
 
+require("../resources/LibraryStyles.css");
+
 import * as React from "react";
 import { LibraryView } from "../LibraryView";
 import { LibraryItem } from "./LibraryItem";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,11 @@
 const webpack = require('webpack');
-let productionBuild = (process.env.production_build == 1);
+let productionBuild = (process.env.NODE_ENV == "production");
 let version = "v0.0.1";
 let plugins = [];
 
 plugins.push(
     new webpack.DefinePlugin({
-        'process.env.NODE_ENV': productionBuild ? JSON.stringify('production') : JSON.stringify('development'),
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         'global': {}
     })
 );
@@ -14,7 +14,7 @@ if (productionBuild) {
     plugins.push(
         new webpack.optimize.UglifyJsPlugin({
             minimize: true,
-            sourceMap: true,
+            sourceMap: true, 
             mangle: {
                 except: ["LibraryView", "on"]
             }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
     output: {
         filename: productionBuild ? "librarie.min.js" : "librarie.js",
         path: __dirname + "/dist/" + version + "/",
+        publicPath: "./dist/" + version,
         libraryTarget: "var",
         library: "LibraryEntryPoint"
     },
@@ -64,11 +65,10 @@ module.exports = {
                 loader: ["style-loader", "css-loader"]
             },
             {
-                test: /\.(png|woff|woff2|eot|ttf|svg)$/,
+                test: /\.ttf$/,
                 loader: "file-loader",
                 options: {
-                    name: '/resources/[name].[ext]',
-                    publicPath: './dist/' + version,
+                    name: '/resources/[name].[ext]'
                 }
             }
         ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,13 @@ let productionBuild = (process.env.production_build == 1);
 let version = "v0.0.1";
 let plugins = [];
 
+plugins.push(
+    new webpack.DefinePlugin({
+        'process.env.NODE_ENV': productionBuild ? JSON.stringify('production') : JSON.stringify('development'),
+        'global': {}
+    })
+);
+
 if (productionBuild) {
     plugins.push(
         new webpack.optimize.UglifyJsPlugin({
@@ -12,8 +19,8 @@ if (productionBuild) {
                 except: ["LibraryView", "on"]
             }
         })
-    )
-};
+    );
+}
 
 module.exports = {
     entry: [
@@ -53,11 +60,11 @@ module.exports = {
                 loader: "source-map-loader" // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
             },
             {
-                test: /\.css$/, 
+                test: /\.css$/,
                 loader: ["style-loader", "css-loader"]
             },
             {
-                test: /\.(png|woff|woff2|eot|ttf|svg)$/, 
+                test: /\.(png|woff|woff2|eot|ttf|svg)$/,
                 loader: "file-loader",
                 options: {
                     name: '/resources/[name].[ext]',
@@ -65,14 +72,5 @@ module.exports = {
                 }
             }
         ]
-    },
-
-    // When importing a module whose path matches one of the following, just
-    // assume a corresponding global variable exists and use that instead.
-    // This is important because it allows us to avoid bundling all of our
-    // dependencies, which allows browsers to cache those libraries between builds.
-    externals: {
-        "react": "React",
-        "react-dom": "ReactDOM"
-    },
+    }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = {
         ],
 
         // Add '.ts' and '.tsx' as resolvable extensions.
-        extensions: [".webpack.js", ".web.js", ".ts", ".tsx", ".js"]
+        extensions: [".webpack.js", ".web.js", ".ts", ".tsx", ".js", ".css"]
     },
 
     module: {
@@ -51,6 +51,18 @@ module.exports = {
                 test: /\.js$/,
                 enforce: "pre",
                 loader: "source-map-loader" // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
+            },
+            {
+                test: /\.css$/, 
+                loader: ["style-loader", "css-loader"]
+            },
+            {
+                test: /\.(png|woff|woff2|eot|ttf|svg)$/, 
+                loader: "file-loader",
+                options: {
+                    name: '/resources/[name].[ext]',
+                    publicPath: './dist/' + version,
+                }
             }
         ]
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ module.exports = {
         ],
 
         // Add '.ts' and '.tsx' as resolvable extensions.
-        extensions: [".webpack.js", ".web.js", ".ts", ".tsx", ".js", ".css"]
+        extensions: [".webpack.js", ".web.js", ".ts", ".tsx", ".js"]
     },
 
     module: {


### PR DESCRIPTION
- Stylesheet and dependencies are removed from `index.html`, because `LibraryStyles.css`, `react.min.js` and `react-dom.min.js` are now all bundled into `librarie.js`/`librarie.min.js`, depending on build environment
- The font is bundled into`./dist/v0.0.1/resources` folder becasue it is directly referenced in `LibraryStyles.css`