### PR TITLE
Hide image when image load fails

### DIFF
--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -89,7 +89,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         // Group displays only text without icon.
         if (this.props.data.itemType != "group") {
             libraryItemTextStyle = "LibraryItemText";
-            iconElement = (<img className={"LibraryItemIcon"} src={this.props.data.iconUrl} />);
+            iconElement = (<img className={"LibraryItemIcon"} src={this.props.data.iconUrl} onError={this.onImageLoadFail} />);
         }
 
         let nestedElements = null;
@@ -120,6 +120,10 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
                 {nestedElements}
             </div>
         );
+    }
+
+    onImageLoadFail(event: any) {
+        event.target.style.visibility = "hidden";
     }
 
     getLibraryItemContainerStyle(): string {


### PR DESCRIPTION
For now the broken image will be hidden when its load fails.
We can add some other icon for this special case later.

*[DYN-737](https://jira.autodesk.com/browse/DYN-737) Replace broken image with icons when icon loading fails*

![capture](https://cloud.githubusercontent.com/assets/14089267/24594493/5db4bd60-1860-11e7-83ee-b7e77d36ffaf.PNG)

@Benglin 