### PR TITLE
Relace lines with arrows for indentation

### DIFF
--- a/src/components/ClusterView.tsx
+++ b/src/components/ClusterView.tsx
@@ -53,7 +53,7 @@ export class ClusterView extends React.Component<ClusterViewProps, undefined> {
 
         let index = 0;
         return this.props.childItems.map((item: ItemData) => {
-            return (<LibraryItem key={index++} libraryView={this.props.libraryView} data={item} indentLevel={0} />);
+            return (<LibraryItem key={index++} libraryView={this.props.libraryView} data={item} />);
         });
     }
 

--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -50,7 +50,7 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
                 );
             } else {
                 let index = 0;
-                const listItems = childItems.map((item: ItemData) => (<LibraryItem key={index++} libraryView={this.props.libraryView} data={item} indentLevel={0}/>));
+                const listItems = childItems.map((item: ItemData) => (<LibraryItem key={index++} libraryView={this.props.libraryView} data={item} />));
                 return (
                     <div>
                         <div>{searchView}</div>

--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -23,8 +23,7 @@ import { ItemData } from "../LibraryUtilities";
 
 export interface LibraryItemProps {
     libraryView: LibraryView,
-    data: ItemData,
-    indentLevel: number
+    data: ItemData
 }
 
 export interface LibraryItemState {
@@ -87,14 +86,13 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         let libraryItemTextStyle = "LibraryItemGroupText";
 
         // Group displays only text without icon.
-        if (this.props.data.itemType != "group") {
+        if (this.props.data.itemType !== "group") {
             libraryItemTextStyle = "LibraryItemText";
             iconElement = (<img className={"LibraryItemIcon"} src={this.props.data.iconUrl} />);
         }
 
         let nestedElements = null;
         let clusteredElements = null;
-        let indentElements = this.getIndentElements();
 
         // visible only nested elements when expanded.
         if (this.state.expanded && this.props.data.childItems.length > 0) {
@@ -109,15 +107,39 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
             nestedElements = this.getNestedElements(groupedItems);
         }
 
+
+        let arrow = null;
+        let bodyIndentation = null;
+
+        // Indentation and arrow are only added for non-category items
+        if (this.props.data.itemType !== "category") {
+
+            // Indent one level for clustered and nested elements
+            if (clusteredElements || nestedElements) {
+                bodyIndentation = (<div className={"BodyIndentation"} />);
+            }
+
+            // Show arrow for non-leaf items
+            if (this.props.data.childItems.length > 0) {
+                let arrowIcon = this.state.expanded ? require("../resources/ui/indent-arrow-down.svg") : require("../resources/ui/indent-arrow-right.svg");
+                arrow = <img className={"Arrow"} src={arrowIcon} />;
+            }
+        }
+
         return (
             <div className={this.getLibraryItemContainerStyle()}>
                 <div className={"LibraryItemHeader"} onClick={this.onLibraryItemClicked.bind(this)} >
-                    {indentElements}
+                    {arrow}
                     {iconElement}
                     <div className={libraryItemTextStyle}>{this.props.data.text}</div>
                 </div>
-                {clusteredElements}
-                {nestedElements}
+                <div className={"LibraryItemBodyContainer"}>
+                    {bodyIndentation}
+                    <div className={"LibraryItemBodyElements"}>
+                        {clusteredElements}
+                        {nestedElements}
+                    </div>
+                </div>
             </div>
         );
     }
@@ -140,27 +162,6 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         return "LibraryItemContainerNone";
     }
 
-    getIndentElements(): JSX.Element {
-        if (this.props.indentLevel <= 0) {
-            return null;
-        }
-
-        let indents: JSX.Element[] = [];
-        let indentationIconRootPath = "/src/resources/ui/";
-
-        for (let i = 1; i <= this.props.indentLevel; i++) {
-            let indentationPath = indentationIconRootPath;
-            if (i == this.props.indentLevel) {
-                indentationPath += "indent-line-t.svg";
-            } else {
-                indentationPath += "indent-line-i.svg";
-            }
-            indents.push(<img key={i} className={"Indentation"} src={indentationPath} />);
-        }
-
-        return (<div className={"Indents"}>{indents}</div>);
-    }
-
     getNestedElements(groupedItems: GroupedItems): JSX.Element {
 
         let regularItems = groupedItems.getOtherItems();
@@ -176,7 +177,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
                     // types of items except ones of type creation/action/query.
                     // 
                     regularItems.map((item: ItemData) => {
-                        return (<LibraryItem key={index++} libraryView={this.props.libraryView} data={item} indentLevel={this.props.indentLevel + 1} />);
+                        return (<LibraryItem key={index++} libraryView={this.props.libraryView} data={item} />);
                     })
                 }
             </div>

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -31,7 +31,7 @@ export class SearchView extends React.Component<SearchViewProps, SearchViewState
         let structuredItems: JSX.Element[] = [];
         let index = 0;
         return this.props.items.map((item: ItemData) =>
-            <LibraryItem key={index++} libraryView={this.props.libraryView} data={item} indentLevel={0}/>);
+            <LibraryItem key={index++} libraryView={this.props.libraryView} data={item} />);
     }
 
     onTextChange(event: any) {

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -44,10 +44,21 @@ body {
     background: rgba(255, 255, 255, 0.1);
 }
 
+.LibraryItemBodyElements {
+    width: 100%;
+}
+
 .LibraryItemBody {
     display: flex;
     flex-direction: column;
     align-items: stretch;
+}
+
+.LibraryItemBodyContainer {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    background: #414141;
 }
 
 .LibraryItemContainerCategory .LibraryItemIcon {
@@ -64,33 +75,33 @@ body {
     -webkit-user-drag: none;
 }
 
+.Arrow + .LibraryItemIcon {
+    padding: 2px 8px 2px 4px;
+}
+
 .LibraryItemContainerCategory .LibraryItemText {
     font-size: 15px;
 }
 
 .LibraryItemContainerNone .LibraryItemText {
     font-size: 13px;
+    padding: 10px 0px;
 }
 
 .LibraryItemGroupText {
+    padding: 10px 0px 10px 5px;
     font-size: 15px;
     color: #a9a9a9;
 }
 
-.Indents {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    padding-left: 20px;
+.Arrow {
+    padding: 10px 10px 10px 12px;
+    height: 13px;
+    width: 13px;
 }
 
-.Indents + .LibraryItemIcon {
-    padding: 0px 10px 0px 0px;
-}
-
-.Indentation {
-    height: 40px;
-    width: 20px;
+.BodyIndentation {
+    padding: 8px;
 }
 
 .ClusterViewContainer {
@@ -100,11 +111,10 @@ body {
 
 .ClusterLeftPane {
     display: flex;
-    padding-left: 35px;
+    padding-left: 20px;
     margin: 2px 0px;
     border-right: 2px;
     border-right-style: solid;
-    justify-content: flex-end;
 }
 
 .ClusterRightPane {

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -95,9 +95,9 @@ body {
 }
 
 .Arrow {
-    padding: 10px 10px 10px 12px;
-    height: 13px;
-    width: 13px;
+    padding: 10px 10px 10px 15px;
+    height: 11px;
+    width: 11px;
 }
 
 .BodyIndentation {

--- a/src/resources/ui/indent-arrow-down.svg
+++ b/src/resources/ui/indent-arrow-down.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
+    <path d="M50 99L7.56 25.5L92.44 25.5z" fill="#aaaaaa"/>
+</svg>

--- a/src/resources/ui/indent-arrow-right.svg
+++ b/src/resources/ui/indent-arrow-right.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
+    <path d="M99 50L25.5 92.44L25.5 7.56z" fill="#aaaaaa"/>
+</svg>

--- a/src/resources/ui/indent-line-i.svg
+++ b/src/resources/ui/indent-line-i.svg
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="20" height="40" viewBox="0 0 20 40" enable-background="new 0 0 20 40" xml:space="preserve">
-  <g stroke="#aaaaaa"  stroke-width="1" width="20" height="40">
-    <line x1="1" y1="0" x2="1" y2="40"/>
-  </g>
-</svg>

--- a/src/resources/ui/indent-line-l.svg
+++ b/src/resources/ui/indent-line-l.svg
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="20" height="40" viewBox="0 0 20 40" enable-background="new 0 0 20 40" xml:space="preserve">
-  <g stroke="#aaaaaa"  stroke-width="1" width="40" height="40">
-    <line x1="1" y1="0" x2="1" y2="20"/>
-    <line x1="1" y1="20" x2="12" y2="20"/>
-  </g>
-</svg>

--- a/src/resources/ui/indent-line-t.svg
+++ b/src/resources/ui/indent-line-t.svg
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="20" height="40" viewBox="0 0 20 40" enable-background="new 0 0 20 40" xml:space="preserve">
-  <g stroke="#aaaaaa"  stroke-width="1" width="20" height="40">
-    <line x1="1" y1="0" x2="1" y2="40"/>
-    <line x1="1" y1="20" x2="12" y2="20"/>
-  </g>
-</svg>

--- a/test/libraryUtilitiesTest.ts
+++ b/test/libraryUtilitiesTest.ts
@@ -316,7 +316,7 @@ describe('constructLibraryItem function', function () {
 
 });
 
-describe('ResetItemData function', function () {
+describe('setItemStateRecursive function', function () {
   var itemArray: LibraryUtilities.ItemData[];
   let itemData1 = new LibraryUtilities.ItemData("1");
   let itemData2 = new LibraryUtilities.ItemData("2");
@@ -330,9 +330,12 @@ describe('ResetItemData function', function () {
     itemArray = [];
   });
 
-  function isAllDefault(items: LibraryUtilities.ItemData[]): boolean {
+  function isSetToValue(items: LibraryUtilities.ItemData[], visible: boolean, expanded: boolean): boolean {
     for (let item of items) {
-      if (!item.visible || item.expanded) {
+      if(item.visible != visible) {
+        return false;
+      }
+      if(item.expanded != expanded) {
         return false;
       }
     }
@@ -340,11 +343,11 @@ describe('ResetItemData function', function () {
   }
 
   it('should work on empty array', function () {
-    LibraryUtilities.resetItemData(itemArray);
-    expect(isAllDefault(itemArray)).to.equal(true);
+    LibraryUtilities.setItemStateRecursive(itemArray, true, false);
+    expect(isSetToValue(itemArray, true, false)).to.equal(true);
   });
 
-  it('should reset the correct attributes', function () {
+  it('should set the correct attributes', function () {
     itemData1.visible = false;
     itemData1.expanded = true;
     itemData2.visible = false;
@@ -354,13 +357,13 @@ describe('ResetItemData function', function () {
     itemArray.push(itemData2);
     itemArray.push(itemData3);
 
-    LibraryUtilities.resetItemData(itemArray);
+    LibraryUtilities.setItemStateRecursive(itemArray, true, false);
 
     expect(itemArray.length).to.equal(3);
-    expect(isAllDefault(itemArray)).to.equal(true);
+    expect(isSetToValue(itemArray, true, false)).to.equal(true);
   });
 
-  it('should reset the correct attributes of child items', function () {
+  it('should set the correct attributes of child items', function () {
     itemData1.visible = false;
     itemData1.expanded = true;
     itemData2.visible = false;
@@ -379,62 +382,9 @@ describe('ResetItemData function', function () {
     itemArray.push(itemData2);
     itemArray.push(itemData3);
 
-    LibraryUtilities.resetItemData(itemArray);
+    LibraryUtilities.setItemStateRecursive(itemArray, false, true);
     expect(itemArray.length).to.equal(3);
-    expect(isAllDefault(itemArray)).to.equal(true);
-  });
-});
-
-describe("ShowItemRecursive function", function () {
-  let itemData1: LibraryUtilities.ItemData;
-  let itemData11: LibraryUtilities.ItemData;
-  let itemData12: LibraryUtilities.ItemData;
-  let itemData111: LibraryUtilities.ItemData;
-
-  beforeEach(function () {
-    itemData1 = new LibraryUtilities.ItemData("1");
-    itemData11 = new LibraryUtilities.ItemData("11");
-    itemData12 = new LibraryUtilities.ItemData("12");
-    itemData111 = new LibraryUtilities.ItemData("111");
-  });
-
-  function isAllSetToTrue(item: LibraryUtilities.ItemData): boolean {
-    if (!(item.visible && item.expanded)) {
-      return false;
-    }
-
-    for (let childItem of item.childItems) {
-      if (!isAllSetToTrue(childItem)) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
-  it('should set one ItemData', function () {
-    itemData1.visible = false;
-    itemData1.expanded = false;
-    LibraryUtilities.showItemRecursive(itemData1);
-    expect(isAllSetToTrue(itemData1)).to.equal(true);
-  });
-
-  it('should set child items', function () {
-    itemData1.visible = false;
-    itemData1.expanded = true;
-    itemData11.visible = false;
-    itemData11.expanded = true;
-    itemData12.visible = false;
-    itemData111.expanded = false;
-
-    itemData11.appendChild(itemData111);
-    itemData1.appendChild(itemData11);
-    itemData1.appendChild(itemData12);
-
-    LibraryUtilities.showItemRecursive(itemData1);
-
-    expect(itemData1.childItems.length).to.equal(2);
-    expect(isAllSetToTrue(itemData1)).to.equal(true);
+    expect(isSetToValue(itemArray, false, true)).to.equal(true);
   });
 });
 

--- a/test/libraryUtilitiesTest.ts
+++ b/test/libraryUtilitiesTest.ts
@@ -316,7 +316,7 @@ describe('constructLibraryItem function', function () {
 
 });
 
-describe('setItemStateRecursive function', function () {
+describe('ResetItemData function', function () {
   var itemArray: LibraryUtilities.ItemData[];
   let itemData1 = new LibraryUtilities.ItemData("1");
   let itemData2 = new LibraryUtilities.ItemData("2");
@@ -330,12 +330,9 @@ describe('setItemStateRecursive function', function () {
     itemArray = [];
   });
 
-  function isSetToValue(items: LibraryUtilities.ItemData[], visible: boolean, expanded: boolean): boolean {
+  function isAllDefault(items: LibraryUtilities.ItemData[]): boolean {
     for (let item of items) {
-      if(item.visible != visible) {
-        return false;
-      }
-      if(item.expanded != expanded) {
+      if (!item.visible || item.expanded) {
         return false;
       }
     }
@@ -343,11 +340,11 @@ describe('setItemStateRecursive function', function () {
   }
 
   it('should work on empty array', function () {
-    LibraryUtilities.setItemStateRecursive(itemArray, true, false);
-    expect(isSetToValue(itemArray, true, false)).to.equal(true);
+    LibraryUtilities.resetItemData(itemArray);
+    expect(isAllDefault(itemArray)).to.equal(true);
   });
 
-  it('should set the correct attributes', function () {
+  it('should reset the correct attributes', function () {
     itemData1.visible = false;
     itemData1.expanded = true;
     itemData2.visible = false;
@@ -357,13 +354,13 @@ describe('setItemStateRecursive function', function () {
     itemArray.push(itemData2);
     itemArray.push(itemData3);
 
-    LibraryUtilities.setItemStateRecursive(itemArray, true, false);
+    LibraryUtilities.resetItemData(itemArray);
 
     expect(itemArray.length).to.equal(3);
-    expect(isSetToValue(itemArray, true, false)).to.equal(true);
+    expect(isAllDefault(itemArray)).to.equal(true);
   });
 
-  it('should set the correct attributes of child items', function () {
+  it('should reset the correct attributes of child items', function () {
     itemData1.visible = false;
     itemData1.expanded = true;
     itemData2.visible = false;
@@ -382,9 +379,62 @@ describe('setItemStateRecursive function', function () {
     itemArray.push(itemData2);
     itemArray.push(itemData3);
 
-    LibraryUtilities.setItemStateRecursive(itemArray, false, true);
+    LibraryUtilities.resetItemData(itemArray);
     expect(itemArray.length).to.equal(3);
-    expect(isSetToValue(itemArray, false, true)).to.equal(true);
+    expect(isAllDefault(itemArray)).to.equal(true);
+  });
+});
+
+describe("ShowItemRecursive function", function () {
+  let itemData1: LibraryUtilities.ItemData;
+  let itemData11: LibraryUtilities.ItemData;
+  let itemData12: LibraryUtilities.ItemData;
+  let itemData111: LibraryUtilities.ItemData;
+
+  beforeEach(function () {
+    itemData1 = new LibraryUtilities.ItemData("1");
+    itemData11 = new LibraryUtilities.ItemData("11");
+    itemData12 = new LibraryUtilities.ItemData("12");
+    itemData111 = new LibraryUtilities.ItemData("111");
+  });
+
+  function isAllSetToTrue(item: LibraryUtilities.ItemData): boolean {
+    if (!(item.visible && item.expanded)) {
+      return false;
+    }
+
+    for (let childItem of item.childItems) {
+      if (!isAllSetToTrue(childItem)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  it('should set one ItemData', function () {
+    itemData1.visible = false;
+    itemData1.expanded = false;
+    LibraryUtilities.showItemRecursive(itemData1);
+    expect(isAllSetToTrue(itemData1)).to.equal(true);
+  });
+
+  it('should set child items', function () {
+    itemData1.visible = false;
+    itemData1.expanded = true;
+    itemData11.visible = false;
+    itemData11.expanded = true;
+    itemData12.visible = false;
+    itemData111.expanded = false;
+
+    itemData11.appendChild(itemData111);
+    itemData1.appendChild(itemData11);
+    itemData1.appendChild(itemData12);
+
+    LibraryUtilities.showItemRecursive(itemData1);
+
+    expect(itemData1.childItems.length).to.equal(2);
+    expect(isAllSetToTrue(itemData1)).to.equal(true);
   });
 });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,7 +65,7 @@ module.exports = {
                 loader: ["style-loader", "css-loader"]
             },
             {
-                test: /\.ttf$/,
+                test: /\.ttf|.svg$/,
                 loader: "file-loader",
                 options: {
                     name: '/resources/[name].[ext]'


### PR DESCRIPTION

- Removed prop `indentLevel` from `LibraryItem` component
- Use arrow to indicate indentation, which will change its direction when the item is expanded
- Add `bodyIndentation` for `LibraryItemBodyContainer`, which contains `{clusteredElements}` or `nestedElements`

**Gif that shows the indentation in normal library view**

![capture1](https://cloud.githubusercontent.com/assets/14089267/24687506/80f22c9e-19ec-11e7-9e9f-fb164d7f213c.gif)
