### PR TITLE
Allow LibraryView to accept JSON objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The following simple HTML code illustrates the way to embed library view into an
 
 - `layoutSpecsUrl` - This represents a relative or absolute URL from where [Layout Specification](./docs/v0.0.1/layout-specs.md) JSON data is to be downloaded.
 
+- `loadedTypes` - The JSON object to be used by library view as Loaded Data Types. If this is not provided, the JSON data will be downloaded from `loadedTypesUrl`.
+
+- `layoutSpecs` - The JSON object to be used by library view as Layout Specification. If this is not provided, the JSON data will be downloaded from `layoutSpecsUrl`.
+
 ```html
 <!DOCTYPE html>
 <html>

--- a/src/LibraryView.tsx
+++ b/src/LibraryView.tsx
@@ -9,7 +9,9 @@ import { Reactor, Event } from "./EventHandler";
 export interface LibraryViewConfig {
     htmlElementId: string,
     loadedTypesUrl: string,
-    layoutSpecsUrl: string
+    layoutSpecsUrl: string,
+    loadedTypes: JSON,
+    layoutSpecs: JSON
 }
 
 export class LibraryView {
@@ -28,7 +30,15 @@ export class LibraryView {
         this.reactor = new Reactor();
 
         this.htmlElementId = config.htmlElementId;
-        this.prefetchContents(config.loadedTypesUrl, config.layoutSpecsUrl);
+
+        if ((config.loadedTypes) && (config.layoutSpecs)) {
+            this.loadedTypesJson = config.loadedTypes;
+            this.layoutSpecsJson = config.layoutSpecs;
+            this.updateContentsInternal();
+        }
+        else {
+            this.prefetchContents(config.loadedTypesUrl, config.layoutSpecsUrl);
+        }
     }
 
     setLoadedTypesJson(loadedTypesJson: any): void {


### PR DESCRIPTION
### Purpose

This PR adds two `JSON` objects to `LibraryViewConfig`. If no `JSON` objects are provided, the `LibraryView` will fetch the `JSON` data from the URLs instead.

### Reviewers

@sharadkjaiswal 

### FYIs

@Benglin 