### PR TITLE
bundle cluster icons into dist folder

### DIFF
--- a/src/components/ClusterView.tsx
+++ b/src/components/ClusterView.tsx
@@ -24,7 +24,7 @@ import { ItemData } from "../LibraryUtilities";
 
 export interface ClusterViewProps {
     libraryView: LibraryView,
-    iconPath: string,
+    icon: any,
     borderColor: string,
     childItems: ItemData[]
 }
@@ -40,7 +40,7 @@ export class ClusterView extends React.Component<ClusterViewProps, undefined> {
         return (
             <div className={"ClusterViewContainer"}>
                 <div className={"ClusterLeftPane"} style={localStyle}>
-                    <img className={"ClusterIcon"} src={this.props.iconPath} />
+                    <img className={"ClusterIcon"} src={this.props.icon} />
                 </div>
                 <div className={"ClusterRightPane"}>
                     {this.getNestedElements()}

--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -198,7 +198,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         if (creationMethods.length > 0 && creationMethods.some(item => item.visible)) {
             creationCluster = (<ClusterView
                 libraryView={this.props.libraryView}
-                iconPath="src/resources/icons/library-creation.svg"
+                icon={require("../resources/icons/library-creation.svg")}
                 borderColor="#62895b" /* green */
                 childItems={creationMethods} />);
         }
@@ -207,7 +207,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         if (actionMethods.length > 0 && actionMethods.some(item => item.visible)) {
             actionCluster = (<ClusterView
                 libraryView={this.props.libraryView}
-                iconPath="src/resources/icons/library-action.svg"
+                icon={require("../resources/icons/library-action.svg")}
                 borderColor="#ad5446" /* red */
                 childItems={actionMethods} />);
         }
@@ -216,7 +216,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         if (queryMethods.length > 0 && queryMethods.some(item => item.visible)) {
             queryCluster = (<ClusterView
                 libraryView={this.props.libraryView}
-                iconPath="src/resources/icons/library-query.svg"
+                icon={require("../resources/icons/library-query.svg")}
                 borderColor="#4b9dbf" /* blue */
                 childItems={queryMethods} />);
         }


### PR DESCRIPTION
The three icons for cluster icon type are now bundled into `./dist/v0.0.1/resources` folder.

@sharadkjaiswal @Benglin 