### PR TITLE
Update the webpack config file to support modules.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+"use strict";
 const webpack = require('webpack');
 let productionBuild = (process.env.NODE_ENV == "production");
 let version = "v0.0.1";
@@ -32,7 +33,7 @@ module.exports = {
         filename: productionBuild ? "librarie.min.js" : "librarie.js",
         path: __dirname + "/dist/" + version + "/",
         publicPath: "./dist/" + version,
-        libraryTarget: "var",
+        libraryTarget: "umd",
         library: "LibraryEntryPoint"
     },
     plugins: plugins,


### PR DESCRIPTION
This PR updates the Output.LibraryTarget to "umd".
This is a way for the library to work with all module definitions (and where aren’t modules at all). It will work with commonjs, amd and as global variable.

@Benglin 