### PR TITLE
Raise two mouse events for library items

### DIFF
--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -128,7 +128,8 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
 
         return (
             <div className={this.getLibraryItemContainerStyle()}>
-                <div className={"LibraryItemHeader"} onClick={this.onLibraryItemClicked.bind(this)} >
+                <div className={"LibraryItemHeader"} onClick={this.onLibraryItemClicked.bind(this)} 
+                        onMouseOver={this.onLibraryItemHoveredOn.bind(this)} onMouseLeave={this.onLibraryItemMouseLeave.bind(this)}>
                     {arrow}
                     {iconElement}
                     <div className={libraryItemTextStyle}>{this.props.data.text}</div>
@@ -243,6 +244,20 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         let libraryContainer = this.props.libraryContainer;
         if (this.props.data.childItems.length == 0) {
             libraryContainer.raiseEvent("itemClicked", this.props.data.contextData);
+        }
+    }
+
+    onLibraryItemHoveredOn() {
+        let libraryContainer = this.props.libraryContainer;
+        if (this.props.data.childItems.length == 0) {
+            libraryContainer.raiseEvent("itemHoveredOn", this.props.data.contextData);
+        }
+    }
+
+    onLibraryItemMouseLeave() {
+        let libraryContainer = this.props.libraryContainer;
+        if (this.props.data.childItems.length == 0) {
+            libraryContainer.raiseEvent("itemMouseLeave", true);
         }
     }
 }

--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -243,21 +243,23 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
 
         let libraryContainer = this.props.libraryContainer;
         if (this.props.data.childItems.length == 0) {
-            libraryContainer.raiseEvent("itemClicked", this.props.data.contextData);
+            libraryContainer.raiseEvent(libraryContainer.props.libraryController.ItemClickedEventName, 
+                this.props.data.contextData);
         }
     }
 
     onLibraryItemHoveredOn() {
         let libraryContainer = this.props.libraryContainer;
         if (this.props.data.childItems.length == 0) {
-            libraryContainer.raiseEvent("itemHoveredOn", this.props.data.contextData);
+            libraryContainer.raiseEvent(libraryContainer.props.libraryController.ItemHoveredOnEventName,
+                this.props.data.contextData);
         }
     }
 
     onLibraryItemMouseLeave() {
         let libraryContainer = this.props.libraryContainer;
         if (this.props.data.childItems.length == 0) {
-            libraryContainer.raiseEvent("itemMouseLeave", true);
+            libraryContainer.raiseEvent(libraryContainer.props.libraryController.ItemMouseLeaveEventName, true);
         }
     }
 }

--- a/src/entry-point.tsx
+++ b/src/entry-point.tsx
@@ -15,6 +15,10 @@ export function CreateLibraryController() {
 
 export class LibraryController {
 
+    ItemClickedEventName = "itemClicked";
+    ItemHoveredOnEventName = "itemHoveredOn";
+    ItemMouseLeaveEventName = "itemMouseLeave";
+
     reactor: Reactor = null;
 
     constructor() {


### PR DESCRIPTION
### Purpose

This is to raise mouse events when the mouse hovers over on library items or leaves them.
- "itemHoveredOn"
- "itemMouseLeave"

BTW, string properties are defined for these event names and an old one - "itemClicked".

### Reviewers
@sharadkjaiswal 

### FYIs
@Benglin