### PR TITLE
Response to a different mouse event and pass y position as well

### DIFF
--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -17,6 +17,7 @@
 */
 
 import * as React from "react";
+import * as ReactDOM from "react-dom";
 import { ClusterView } from "./ClusterView";
 import { LibraryContainer } from "./LibraryContainer";
 import { ItemData } from "../LibraryUtilities";
@@ -128,8 +129,10 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
 
         return (
             <div className={this.getLibraryItemContainerStyle()}>
-                <div className={"LibraryItemHeader"} onClick={this.onLibraryItemClicked.bind(this)} 
-                        onMouseOver={this.onLibraryItemHoveredOn.bind(this)} onMouseLeave={this.onLibraryItemMouseLeave.bind(this)}>
+                <div className={"LibraryItemHeader"} 
+                        onClick={this.onLibraryItemClicked.bind(this)} 
+                        onMouseEnter={this.onLibraryItemMouseEnter.bind(this)}
+                        onMouseLeave={this.onLibraryItemMouseLeave.bind(this)}>
                     {arrow}
                     {iconElement}
                     <div className={libraryItemTextStyle}>{this.props.data.text}</div>
@@ -248,18 +251,20 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         }
     }
 
-    onLibraryItemHoveredOn() {
-        let libraryContainer = this.props.libraryContainer;
-        if (this.props.data.childItems.length == 0) {
-            libraryContainer.raiseEvent(libraryContainer.props.libraryController.ItemHoveredOnEventName,
-                this.props.data.contextData);
-        }
-    }
-
     onLibraryItemMouseLeave() {
         let libraryContainer = this.props.libraryContainer;
         if (this.props.data.childItems.length == 0) {
             libraryContainer.raiseEvent(libraryContainer.props.libraryController.ItemMouseLeaveEventName, true);
+        }
+    }
+
+    onLibraryItemMouseEnter() {
+        let libraryContainer = this.props.libraryContainer;
+        if (this.props.data.childItems.length == 0) {
+            var rect = ReactDOM.findDOMNode(this).getBoundingClientRect();
+            let middle = (rect.bottom + rect.top)/2.0;
+            libraryContainer.raiseEvent(libraryContainer.props.libraryController.ItemMouseEnterEventName, 
+                                            {name: this.props.data.contextData, posY: middle});
         }
     }
 }

--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -254,17 +254,17 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
     onLibraryItemMouseLeave() {
         let libraryContainer = this.props.libraryContainer;
         if (this.props.data.childItems.length == 0) {
-            libraryContainer.raiseEvent(libraryContainer.props.libraryController.ItemMouseLeaveEventName, true);
+            libraryContainer.raiseEvent(libraryContainer.props.libraryController.ItemMouseLeaveEventName,
+                                            {data: this.props.data.contextData});
         }
     }
 
     onLibraryItemMouseEnter() {
         let libraryContainer = this.props.libraryContainer;
         if (this.props.data.childItems.length == 0) {
-            var rect = ReactDOM.findDOMNode(this).getBoundingClientRect();
-            let middle = (rect.bottom + rect.top)/2.0;
+            var rec = ReactDOM.findDOMNode(this).getBoundingClientRect();
             libraryContainer.raiseEvent(libraryContainer.props.libraryController.ItemMouseEnterEventName, 
-                                            {name: this.props.data.contextData, posY: middle});
+                                            {data: this.props.data.contextData, rect: rec});
         }
     }
 }

--- a/src/entry-point.tsx
+++ b/src/entry-point.tsx
@@ -16,7 +16,7 @@ export function CreateLibraryController() {
 export class LibraryController {
 
     ItemClickedEventName = "itemClicked";
-    ItemHoveredOnEventName = "itemHoveredOn";
+    ItemMouseEnterEventName = "itemMouseEnter";
     ItemMouseLeaveEventName = "itemMouseLeave";
 
     reactor: Reactor = null;


### PR DESCRIPTION
### Purpose

This is a folow-up for https://github.com/DynamoDS/librarie.js/pull/29.

Here as the onMouseOver event can be triggered multiple times even it is on the same item, onMouseEnter event will be listened instead to avoid unnecessary computation.

Also the y postion of the item is obtained and passed as well.

### Reviewers
@Benglin @sharadkjaiswal 

### FYIs
@riteshchandawar @monikaprabhu 
