### PR TITLE
Allow search in keywords

### DIFF
--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -486,7 +486,6 @@ function buildLibraryItemsFromName(typeListNode: TypeListNode, parentNode: ItemD
 
     // Otherwise, create the new parent node 'A' (using the previous example).
     let newParentNode = new ItemData(fullyQualifiedNameParts[0]);
-    let keywords = typeListNode.keywords.split(",");
     newParentNode.contextData = typeListNode.contextData;
     newParentNode.iconUrl = typeListNode.iconUrl;
     newParentNode.itemType = "group";

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -545,7 +545,16 @@ export function searchItemResursive(items: ItemData[], text: string) {
     }
 }
 
-export function getHighlightedText(text: string, highlightedText: string): React.DOMElement<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>[] {
+export function getHighlightedText(text: string, highlightedText: string, matchDelimiter: boolean): React.DOMElement<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>[] {
+    if (matchDelimiter) {
+        let delimiter = ".";
+        if (highlightedText.includes(delimiter)) {
+            let texts = highlightedText.split(delimiter);
+            let matchedText = texts.find(x => text.toLowerCase().includes(x));
+            highlightedText = matchedText ? matchedText : highlightedText;
+        }
+    }
+
     let regex = new RegExp(highlightedText, 'gi');
     let segments = text.split(regex);
     let replacements = text.match(regex);

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -498,7 +498,12 @@ function buildLibraryItemsFromName(typeListNode: TypeListNode, parentNode: ItemD
 // Get keywords from typeListNode and push them into itemData
 export function pushKeywords(itemData: ItemData, typeListNode: TypeListNode) {
     let keywords = typeListNode.keywords.split(",");
-    keywords.forEach(keyword => itemData.keywords.push(keyword.toLowerCase().trim()));
+    keywords.forEach(keyword => {
+        itemData.keywords.push(keyword.toLowerCase().trim())
+    });
+
+    let index = typeListNode.contextData.indexOf("@");
+    itemData.keywords.push(typeListNode.contextData.substring(0, index).toLowerCase());
 }
 
 // Recursively set visible and expanded states of ItemData
@@ -513,11 +518,8 @@ export function setItemStateRecursive(items: ItemData | ItemData[], visible: boo
 
 export function search(text: string, item: ItemData) {
     if (item.itemType !== "group") {
-        let index = -1;
-
         for (let keyword of item.keywords) {
-            index = keyword.indexOf(text);
-            if (index >= 0) {
+            if (keyword.includes(text)) {
                 // Show all items recursively if a given text is found in the current 
                 // (parent) item. Note that this does not apply to items of "group" type
                 setItemStateRecursive(item, true, true);

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -501,9 +501,7 @@ export function pushKeywords(itemData: ItemData, typeListNode: TypeListNode) {
     keywords.forEach(keyword => {
         itemData.keywords.push(keyword.toLowerCase().trim())
     });
-
-    let index = typeListNode.contextData.indexOf("@");
-    itemData.keywords.push(typeListNode.contextData.substring(0, index).toLowerCase());
+    itemData.keywords.push(typeListNode.fullyQualifiedName.toLowerCase());
 }
 
 // Recursively set visible and expanded states of ItemData
@@ -551,9 +549,10 @@ export function getHighlightedText(text: string, highlightedText: string, matchD
     if (matchDelimiter) {
         let delimiter = ".";
         if (highlightedText.includes(delimiter)) {
-            let texts = highlightedText.split(delimiter);
-            let matchedText = texts.find(x => text.toLowerCase().includes(x));
-            highlightedText = matchedText ? matchedText : highlightedText;
+            let leafText = highlightedText.split(delimiter).pop();
+            if (text.toLowerCase().includes(leafText)) {
+                highlightedText = leafText;
+            }
         }
     }
 

--- a/src/components/SearchResultItem.tsx
+++ b/src/components/SearchResultItem.tsx
@@ -19,8 +19,8 @@ export class SearchResultItem extends React.Component<SearchResultItemProps, Sea
 
     render() {
         let iconPath = this.props.data.iconUrl;
-        let highLightedItemText = getHighlightedText(this.props.data.text, this.props.highlightedText);
-        let highLightedCategoryText = getHighlightedText(this.props.category, this.props.highlightedText);
+        let highLightedItemText = getHighlightedText(this.props.data.text, this.props.highlightedText, true);
+        let highLightedCategoryText = getHighlightedText(this.props.category, this.props.highlightedText, false);
         let ItemTypeIconPath = "src/resources/icons/library-" + this.props.data.itemType + ".svg";
 
         return (


### PR DESCRIPTION
- `keywords` will be read from `rawTypeData.json`, and converted to a string array separated by `,`  stored in `ItemData`
- The substring search will go to `keywords` to find matches.
- `contextData` will also be stored in `keywords` for search
- Search string will be highlighted. For example, if the search string is `file.fromPa`, `fromPa` in `fromPath` will be highlighted, as shown in the gif.

![capture2](https://cloud.githubusercontent.com/assets/14089267/25606284/348d801c-2f43-11e7-9961-431ca5866c4e.gif)


### Reviewer
@sharadkjaiswal 

### FYI
@Benglin 