### PR TITLE
using query selector to select child elements

### DIFF
--- a/src/entry-point.tsx
+++ b/src/entry-point.tsx
@@ -42,7 +42,11 @@ export class LibraryController {
     }
 
     createLibraryByElementId(htmlElementId: string, layoutSpecsJson: any, loadedTypesJson: any) {
-        let htmlElement = document.getElementById(htmlElementId);
+        let htmlElement: any;
+        htmlElement = document.querySelector(htmlElementId);
+        if (!htmlElement) {
+            htmlElement = document.getElementById(htmlElementId);
+        }
         return ReactDOM.render(<LibraryContainer
             libraryController={this}
             loadedTypesJson={loadedTypesJson}

--- a/src/entry-point.tsx
+++ b/src/entry-point.tsx
@@ -43,9 +43,9 @@ export class LibraryController {
 
     createLibraryByElementId(htmlElementId: string, layoutSpecsJson: any, loadedTypesJson: any) {
         let htmlElement: any;
-        htmlElement = document.querySelector(htmlElementId);
+        htmlElement = document.querySelector(htmlElementId) || document.getElementById(htmlElementId);
         if (!htmlElement) {
-            htmlElement = document.getElementById(htmlElementId);
+            throw new Error("Element " + htmlElementId + " is not defined");
         }
         return ReactDOM.render(<LibraryContainer
             libraryController={this}


### PR DESCRIPTION
Using ```document.querySelector``` to select the child element based on the given parent element. 
This PR solves the problem of having different parent Id with same child Id. This is one of the use case for AVP.

@Benglin 