### PR TITLE
Collapse siblings when expanding one item

### DIFF
--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -25,7 +25,7 @@ import { ItemData } from "../LibraryUtilities";
 export interface LibraryItemProps {
     libraryContainer: LibraryContainer,
     data: ItemData,
-    onExpand?: Function
+    onItemWillExpand?: Function
 }
 
 export interface LibraryItemState {
@@ -195,7 +195,11 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
                     // types of items except ones of type create/action/query.
                     regularItems.map((item: ItemData) => {
                         return (<LibraryItem
-                            key={index++} libraryContainer={this.props.libraryContainer} data={item} onExpand={this.onExpand.bind(this)} />);
+                            key={index++}
+                            libraryContainer={this.props.libraryContainer}
+                            data={item}
+                            onItemWillExpand={this.onItemWillExpand.bind(this)}
+                        />);
                     })
                 }
             </div>
@@ -252,8 +256,9 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         // Toggle expansion state.
         let currentlyExpanded = this.state.expanded;
         if (this.props.data.childItems.length > 0 && !currentlyExpanded) {
-            this.props.onExpand();
+            this.props.onItemWillExpand();
         }
+        
         this.setState({ expanded: !currentlyExpanded });
 
         let libraryContainer = this.props.libraryContainer;
@@ -263,12 +268,12 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         }
     }
 
-    // Unexpand all other slibling items when one item is being expanded
-    onExpand() {
+    // Collapse all child items when one of the child items is expanded
+    onItemWillExpand() {
         for (let item of this.props.data.childItems) {
             item.expanded = false;
         }
-        this.setState({ expanded: true });
+        this.setState({ expanded: true }); // Make the current item (parent) expanded.
     }
 
     onLibraryItemMouseLeave() {

--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -198,7 +198,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
                             key={index++}
                             libraryContainer={this.props.libraryContainer}
                             data={item}
-                            onItemWillExpand={this.onItemWillExpand.bind(this)}
+                            onItemWillExpand={this.onSingleChildItemWillExpand.bind(this)}
                         />);
                     })
                 }
@@ -269,7 +269,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
     }
 
     // Collapse all child items when one of the child items is expanded
-    onItemWillExpand() {
+    onSingleChildItemWillExpand() {
         for (let item of this.props.data.childItems) {
             item.expanded = false;
         }

--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -24,7 +24,8 @@ import { ItemData } from "../LibraryUtilities";
 
 export interface LibraryItemProps {
     libraryContainer: LibraryContainer,
-    data: ItemData
+    data: ItemData,
+    onExpand?: Function
 }
 
 export interface LibraryItemState {
@@ -193,7 +194,8 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
                     // 'getNestedElements' method is meant to render all other 
                     // types of items except ones of type create/action/query.
                     regularItems.map((item: ItemData) => {
-                        return (<LibraryItem key={index++} libraryContainer={this.props.libraryContainer} data={item} />);
+                        return (<LibraryItem
+                            key={index++} libraryContainer={this.props.libraryContainer} data={item} onExpand={this.onExpand.bind(this)} />);
                     })
                 }
             </div>
@@ -249,6 +251,9 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
     onLibraryItemClicked() {
         // Toggle expansion state.
         let currentlyExpanded = this.state.expanded;
+        if (this.props.data.childItems.length > 0 && !currentlyExpanded) {
+            this.props.onExpand();
+        }
         this.setState({ expanded: !currentlyExpanded });
 
         let libraryContainer = this.props.libraryContainer;
@@ -256,6 +261,14 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
             libraryContainer.raiseEvent(libraryContainer.props.libraryController.ItemClickedEventName,
                 this.props.data.contextData);
         }
+    }
+
+    // Unexpand all other slibling items when one item is being expanded
+    onExpand() {
+        for (let item of this.props.data.childItems) {
+            item.expanded = false;
+        }
+        this.setState({ expanded: true });
     }
 
     onLibraryItemMouseLeave() {


### PR DESCRIPTION
[*DYN - 823 Implement expanding of one item collapses the other siblings*](https://jira.autodesk.com/browse/DYN-823)

![capture2](https://cloud.githubusercontent.com/assets/14089267/25735223/5c5073d8-319c-11e7-8d1c-974986936a48.gif)


### Reviewer 
@Benglin 

### FYI
@riteshchandawar 