### PR TITLE
Library scroll

### DIFF
--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -62,7 +62,9 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
             return (
                 <div>
                     {searchView}
-                    {sections}
+                    <div className="LibraryItemContainer">
+                        {sections}
+                    </div>
                 </div>
             );
         } catch (exception) {

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -32,6 +32,11 @@ input {
     font-family: "Artifakt Element", "Open Sans";
 }
 
+.LibraryItemContainer {
+    height: calc(100vh - 40px);
+    overflow-y: scroll;
+}
+
 .LibraryItemContainerSection {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### Purpose

*[DYN-819](https://jira.autodesk.com/browse/DYN-819) Scroll for the library should be restricted to Library Items only.*

The search bar should not be scrollable together with the library contents!

### Before & After screenshots

![image](https://cloud.githubusercontent.com/assets/6386550/25930744/9d0d1230-363a-11e7-83aa-6ae819405cda.png)

### Reviewers

@gohb 

### FYIs

@riteshchandawar 

![image](http://oi63.tinypic.com/10zs93t.jpg)