### PR TITLE
Display parameters for overloads in search results

### DIFF
--- a/src/components/SearchResultItem.tsx
+++ b/src/components/SearchResultItem.tsx
@@ -19,6 +19,7 @@ export class SearchResultItem extends React.Component<SearchResultItemProps, Sea
 
     render() {
         let iconPath = this.props.data.iconUrl;
+        let parameters = this.props.data.parameters;
         let highLightedItemText = getHighlightedText(this.props.data.text, this.props.highlightedText, true);
         let highLightedCategoryText = getHighlightedText(this.props.category, this.props.highlightedText, false);
         let ItemTypeIconPath = "src/resources/icons/library-" + this.props.data.itemType + ".svg";
@@ -27,7 +28,7 @@ export class SearchResultItem extends React.Component<SearchResultItemProps, Sea
             <div className={"SearchResultItemContainer"} onClick={this.onItemClicked.bind(this)}>
                 <img className={"ItemIcon"} src={iconPath} onError={this.onImageLoadFail.bind(this)} />
                 <div className={"ItemInfo"}>
-                    <div className={"ItemTitle"}>{highLightedItemText}</div>
+                    <div className={"ItemTitle"}>{highLightedItemText}<div className={"LibraryItemParameters"}>{parameters}</div></div>
                     <div className={"ItemDetails"}>
                         <img className={"ItemTypeIcon"} src={ItemTypeIconPath} onError={this.onImageLoadFail.bind(this)} />
                         <div className={"ItemCategory"}>{highLightedCategoryText}</div>

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -166,6 +166,7 @@ input {
     color: #888;
     font-size: 9pt;
     margin-left: 5px;
+    display: inline-block;
 }
 
 .Arrow {


### PR DESCRIPTION
Display parameters for overloads in search results (for list view):
![searchparams](https://cloud.githubusercontent.com/assets/17231814/25980525/af5230d4-3701-11e7-9a88-526ffcef41c5.PNG)

@Benglin @fanwgwg 