### PR TITLE
Suppress console warnings during tests

### DIFF
--- a/test/libraryUtilitiesTest.ts
+++ b/test/libraryUtilitiesTest.ts
@@ -256,12 +256,14 @@ describe('constructLibraryItem function', function () {
   beforeEach(function () {
     layoutElements = [];
     typeListNodes = [];
-    console.warn = function() {};
+
+    // Suppress logging to console during test runs
+    console.warn = function () { };
   });
 
-  afterEach(function() {
+  afterEach(function () {
     // Reset console.warn that was suppressed
-    delete(console.warn);
+    delete (console.warn);
   })
 
   it('should construct an empty LibraryItem', function () {
@@ -622,12 +624,13 @@ describe('convertToDefaultSection and convertToMiscSection functions', function 
     miscSection.text = "Miscellaneous";
     layoutElements.push(miscSection);
 
-    console.warn = function() {};
+    // Suppress logging to console during test runs
+    console.warn = function () { };
   })
 
-  afterEach(function() {
+  afterEach(function () {
     // Reset console.warn that was suppressed
-    delete(console.warn);
+    delete (console.warn);
   })
 
   it('should correctly construct default section', function () {
@@ -668,7 +671,7 @@ describe('convertToDefaultSection and convertToMiscSection functions', function 
     expect(miscSection.childItems.length).to.equal(0);
   })
 
-  it('should construct left-over items in Miscellaneous section', function() {
+  it('should construct left-over items in Miscellaneous section', function () {
     let layoutElement = new LibraryUtilities.LayoutElement(new testClasses.LayoutElementData());
     layoutElement.text = 'x';
     layoutElement.include = [];
@@ -787,8 +790,8 @@ describe('buildLibraryItemsFromName function', function () {
   });
 });
 
-describe('convertSectionToItemData function', function() {
-  it('should convert LayoutElement to ItemData', function() {
+describe('convertSectionToItemData function', function () {
+  it('should convert LayoutElement to ItemData', function () {
     let section = new LibraryUtilities.LayoutElement(new testClasses.LayoutElementData());
     section.text = "test";
     section.elementType = "section";

--- a/test/libraryUtilitiesTest.ts
+++ b/test/libraryUtilitiesTest.ts
@@ -260,6 +260,7 @@ describe('constructLibraryItem function', function () {
   });
 
   afterEach(function() {
+    // Reset console.warn that was suppressed
     delete(console.warn);
   })
 
@@ -625,6 +626,7 @@ describe('convertToDefaultSection and convertToMiscSection functions', function 
   })
 
   afterEach(function() {
+    // Reset console.warn that was suppressed
     delete(console.warn);
   })
 

--- a/test/libraryUtilitiesTest.ts
+++ b/test/libraryUtilitiesTest.ts
@@ -256,7 +256,12 @@ describe('constructLibraryItem function', function () {
   beforeEach(function () {
     layoutElements = [];
     typeListNodes = [];
+    console.warn = function() {};
   });
+
+  afterEach(function() {
+    delete(console.warn);
+  })
 
   it('should construct an empty LibraryItem', function () {
     let layoutElement = new LibraryUtilities.LayoutElement(new testClasses.LayoutElementData());
@@ -615,6 +620,12 @@ describe('convertToDefaultSection and convertToMiscSection functions', function 
     let miscSection = new LibraryUtilities.LayoutElement(new testClasses.LayoutElementSectionData());
     miscSection.text = "Miscellaneous";
     layoutElements.push(miscSection);
+
+    console.warn = function() {};
+  })
+
+  afterEach(function() {
+    delete(console.warn);
   })
 
   it('should correctly construct default section', function () {


### PR DESCRIPTION
Suppress console warnings so that `console.warn()` will not be displayed during tests:
![warns](https://cloud.githubusercontent.com/assets/17231814/26143161/50902006-3b16-11e7-8a88-5c366cc9c0fd.PNG)
