### PR TITLE
Remove whitespace from search

### DIFF
--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -573,9 +573,9 @@ export function buildLibraryItemsFromName(typeListNode: TypeListNode, parentNode
 export function pushKeywords(itemData: ItemData, typeListNode: TypeListNode) {
     let keywords = typeListNode.keywords.split(",");
     keywords.forEach(keyword => {
-        itemData.keywords.push(keyword.toLowerCase().trim())
+        itemData.keywords.push(keyword.toLowerCase().replace(/ /g, ''));
     });
-    itemData.keywords.push(typeListNode.fullyQualifiedName.toLowerCase());
+    itemData.keywords.push(typeListNode.fullyQualifiedName.toLowerCase().replace(/ /g, ''));
 }
 
 // Recursively set visible and expanded states of ItemData

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -62,7 +62,7 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     }
 
     onTextChanged(event: any) {
-        let text = event.target.value.trim().toLowerCase();
+        let text = event.target.value.toLowerCase().replace(/ /g,'');
         this.setState({ hasText: text.length > 0 });
         this.props.onTextChanged(text);
     }


### PR DESCRIPTION
e.g. Search for `By Coordinates` can return the result that contains `bycoordinates`

### Reviewer
@sharadkjaiswal 

### FYI
@riteshchandawar 