### PR TITLE
New APIs introduced for librarie.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Constructing library view given the ID of an existing HTML element:
 
 - `htmlElementId` - The ID of an HTML whose content is to be replaced with `LibraryContainer`.
 
-- `loadedTypesJsonObject` - The JSON object to be used by library view as Loaded Data Types. This argument is mandatory.
+- `loadedTypesJsonObject` - The JSON object to be used by library view as Loaded Data Types. This argument is optional, but if it is supplied, the corresponding `layoutSpecsJsonObject` must also be supplied. If this argument is not supplied, see *Method 2* below for details on how it can be supplied at a later time.
 
-- `layoutSpecsJsonObject` - The JSON object to be used by library view as Layout Specification. This argument is mandatory.
+- `layoutSpecsJsonObject` - The JSON object to be used by library view as Layout Specification. This argument is optional, but if it is supplied, the corresponding `loadedTypesJsonObject` must also be supplied. If this argument is not supplied, see *Method 2* below for details on how it can be supplied at a later time.
 
 ### Method 2
 Constructing a library view for consumption by other React.js components (e.g. hosting the library within a React.js tab control). This method creates a valid `JSX.Element` object so that it can be directly embedded under another React.js element. For details of `loadedTypesJsonObject` and `layoutSpecsJsonObject`, please refer to the above section.
@@ -67,11 +67,15 @@ Constructing a library view for consumption by other React.js components (e.g. h
 ```html
     <script>
         let libController = LibraryEntryPoint.CreateLibraryController();
-        let libContainer = libController.createLibraryContainer(,
-            loadedTypesJsonObject, layoutSpecsJsonObject);
+        let libContainer = libController.createLibraryContainer();
 
         let aReactJsTabContainer = ...;
         aReactJsTabContainer.addTabPage(libContainer);
+
+        // Supply loaded types and layout specs at a much later time.
+        libController.setLoadedTypesJson(loadedTypesJsonObject);
+        libController.setLayoutSpecsJson(layoutSpecsJsonObject);
+        libController.refreshLibraryView(); // Refresh library view.
     </script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Constructing a library view for consumption by other React.js components (e.g. h
         aReactJsTabContainer.addTabPage(libContainer);
 
         // Supply loaded types and layout specs at a much later time.
-        libController.setLoadedTypesJson(loadedTypesJsonObject);
-        libController.setLayoutSpecsJson(layoutSpecsJsonObject);
+        let append = false; // Replace existing contents instead of appending.
+        libController.setLoadedTypesJson(loadedTypesJsonObject, append);
+        libController.setLayoutSpecsJson(layoutSpecsJsonObject, append);
         libController.refreshLibraryView(); // Refresh library view.
     </script>
 ```

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -504,7 +504,23 @@ function updateElement(oldElement: LayoutElement, newElement: LayoutElement, app
                 });
             }
         }
+    }
 
+    // Done handling 'include' property, proceed to deal with 'childElements'
+    for (let childElement of newElement.childElements) {
+
+        let nameOfChildToUpdate = childElement.text;
+        let childToUpdate = oldElement.childElements.find(function (c) {
+            return c.text === nameOfChildToUpdate;
+        });
+
+        if (!childToUpdate) {
+            // If no existing child is found, insert the new element directly.
+            oldElement.childElements.push(childElement);
+        } else {
+            // If an existing child is found, update it recursively.
+            updateElement(childToUpdate, childElement, append);
+        }
     }
 }
 

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -464,6 +464,9 @@ export function convertSectionToItemData(section: LayoutElement): ItemData {
     return sectionData;
 }
 
+export function updateSections(oldElement: LayoutElement, newElement: LayoutElement, append: boolean): void {
+}
+
 /**
  * Convert an array of typeListNodes to ItemData which are not processed based on their fullyQualifiedNames, 
  * by splitting the name with '.', and put them under a specific section.

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -464,7 +464,44 @@ export function convertSectionToItemData(section: LayoutElement): ItemData {
     return sectionData;
 }
 
-export function updateSections(oldElement: LayoutElement, newElement: LayoutElement, append: boolean): void {
+function updateElement(oldElement: LayoutElement, newElement: LayoutElement, append: boolean): void {
+}
+
+// See 'updateElement' method above for details.
+export function updateSections(oldLayoutSpecs: any, newLayoutSpecs: any, append: boolean): void {
+
+    if (!oldLayoutSpecs || (!newLayoutSpecs)) {
+        throw new Error("Both 'oldLayoutSpecs' and 'newLayoutSpecs' parameters must be supplied");
+    }
+
+    if (!oldLayoutSpecs.sections || (!Array.isArray(oldLayoutSpecs.sections))) {
+        throw new Error("'oldLayoutSpecs.sections' must be a valid array");
+    }
+
+    if (!newLayoutSpecs.sections || (!Array.isArray(newLayoutSpecs.sections))) {
+        throw new Error("'newLayoutSpecs.sections' must be a valid array");
+    }
+
+    // Go through each of the new sections...
+    for (let section of newLayoutSpecs.sections) {
+
+        // Find out the corresponding old section (with the same name) to update.
+        let sectionNameToUpdate = section.text;
+        let sectionToUpdate = oldLayoutSpecs.sections.find(
+            function (s: LayoutElement) {
+                return s.text === sectionNameToUpdate
+            });
+
+        // If section with the same name cannot be found, then this is a new section.
+        // Append the new section and then proceed to check on the next section.
+        if (!sectionToUpdate) {
+            oldLayoutSpecs.sections.push(section);
+            continue;
+        }
+
+        // Recursively update the element and its child elements.
+        updateElement(sectionToUpdate, section, append);
+    }
 }
 
 /**

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -465,6 +465,47 @@ export function convertSectionToItemData(section: LayoutElement): ItemData {
 }
 
 function updateElement(oldElement: LayoutElement, newElement: LayoutElement, append: boolean): void {
+
+    // Duplicate basic properties.
+    oldElement.text = newElement.text;
+    oldElement.iconUrl = newElement.iconUrl;
+    oldElement.showHeader = newElement.showHeader;
+    oldElement.elementType = newElement.elementType;
+
+    if (!append) { // Deal with include path information.
+
+        // Replacing (not appending) existing include paths.
+        oldElement.include = []; // Reset the original array before merging with the new one.
+        Array.prototype.push.apply(oldElement.include, newElement.include);
+
+    } else {
+
+        // Find an existing IncludeInfo that matches the new IncludeInfo. 
+        // If one is found, then its contents are updated to match the new 
+        // IncludeInfo, otherwise the new IncludeInfo will be appended to
+        // the existing include list.
+        // 
+        for (let pathInfo of newElement.include) {
+            let pathToUpdate = oldElement.include.find(function (p: IncludeInfo) {
+                return p.path === pathInfo.path;
+            });
+
+            if (pathToUpdate) {
+                // An existing entry is found, update its contents.
+                pathToUpdate.path = pathInfo.path;
+                pathToUpdate.iconUrl = pathInfo.iconUrl + "Hey";
+                pathToUpdate.inclusive = pathInfo.inclusive;
+            } else {
+                // No existing entry is found, make a copy of the new IncludeInfo
+                oldElement.include.push({
+                    path: pathInfo.path,
+                    iconUrl: pathInfo.iconUrl,
+                    inclusive: pathInfo.inclusive
+                });
+            }
+        }
+
+    }
 }
 
 // See 'updateElement' method above for details.

--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -82,14 +82,15 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
             throw new Error("'layoutSpecsJson.sections' must be a valid array");
         }
 
-        // If there is no existing layoutSpecsJson, simply assign one and done.
-        if (!this.layoutSpecsJson) {
+        // If there is no existing layoutSpecsJson object, or the call
+        // is meant to replace the existing one, then assign it and bail.
+        if (!this.layoutSpecsJson || (!append)) {
             this.layoutSpecsJson = layoutSpecsJson;
             return;
         }
 
         // Otherwise, recursively replace/append each section.
-        updateSections(this.layoutSpecsJson, layoutSpecsJson, append);
+        updateSections(this.layoutSpecsJson, layoutSpecsJson);
     }
 
     raiseEvent(name: string, params?: any | any[]) {

--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -25,6 +25,9 @@ export interface LibraryContainerStates {
 
 export class LibraryContainer extends React.Component<LibraryContainerProps, LibraryContainerStates> {
 
+    loadedTypesJson: any = null;
+    layoutSpecsJson: any = null;
+
     generatedSections: ItemData[] = null;
     searchCategories: string[] = [];
 
@@ -48,10 +51,28 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
         }
     }
 
-    setLoadedTypesJson(loadedTypesJson: any): void {
+    setLoadedTypesJson(loadedTypesJson: any, append: boolean = true): void {
+
+        if (!loadedTypesJson) {
+            throw new Error("Parameter 'loadedTypesJson' must be supplied");
+        }
+
+        if (!loadedTypesJson.loadedTypes || (!Array.isArray(loadedTypesJson.loadedTypes))) {
+            throw new Error("'loadedTypesJson.loadedTypes' must be a valid array");
+        }
+
+        // To replace the current loadedTypesJson entirely. The same happens 
+        // when there is not already an existing loadedTypesJson object.
+        if (!append || (!this.loadedTypesJson)) {
+            this.loadedTypesJson = loadedTypesJson;
+            return;
+        }
+
+        // To append to the existing 'loadedTypesJson.loadedTypes object' (merge both arrays).
+        Array.prototype.push.apply(this.loadedTypesJson.loadedTypes, loadedTypesJson.loadedTypes);
     }
 
-    setLayoutSpecsJson(layoutSpecsJson: any): void {
+    setLayoutSpecsJson(layoutSpecsJson: any, append: boolean = true): void {
     }
 
     raiseEvent(name: string, params?: any | any[]) {

--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { LibraryController } from "../entry-point";
 import { LibraryItem } from "./LibraryItem";
 import { SearchView } from "./SearchView";
-import { buildLibrarySectionsFromLayoutSpecs, ItemData } from "../LibraryUtilities";
+import { buildLibrarySectionsFromLayoutSpecs, updateSections, ItemData } from "../LibraryUtilities";
 
 declare var boundContainer: any; // Object set from C# side.
 
@@ -61,9 +61,9 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
             throw new Error("'loadedTypesJson.loadedTypes' must be a valid array");
         }
 
-        // To replace the current loadedTypesJson entirely. The same happens 
-        // when there is not already an existing loadedTypesJson object.
-        if (!append || (!this.loadedTypesJson)) {
+        // If there is no existing loadedTypesJson object, or the call
+        // is meant to replace the existing one, then assign it and bail.
+        if (!this.loadedTypesJson || (!append)) {
             this.loadedTypesJson = loadedTypesJson;
             return;
         }
@@ -73,6 +73,23 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
     }
 
     setLayoutSpecsJson(layoutSpecsJson: any, append: boolean = true): void {
+
+        if (!layoutSpecsJson) {
+            throw new Error("Parameter 'layoutSpecsJson' must be supplied");
+        }
+
+        if (!layoutSpecsJson.sections || (!Array.isArray(layoutSpecsJson.sections))) {
+            throw new Error("'layoutSpecsJson.sections' must be a valid array");
+        }
+
+        // If there is no existing layoutSpecsJson, simply assign one and done.
+        if (!this.layoutSpecsJson) {
+            this.layoutSpecsJson = layoutSpecsJson;
+            return;
+        }
+
+        // Otherwise, recursively replace/append each section.
+        updateSections(this.layoutSpecsJson, layoutSpecsJson, append);
     }
 
     raiseEvent(name: string, params?: any | any[]) {

--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -30,15 +30,28 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
 
     constructor(props: LibraryContainerProps) {
         super(props);
+
+        // Bind function prototypes to the object instance.
+        this.setLoadedTypesJson = this.setLoadedTypesJson.bind(this);
+        this.setLayoutSpecsJson = this.setLayoutSpecsJson.bind(this);
+        this.onSearchModeChanged = this.onSearchModeChanged.bind(this);
+
         this.state = { inSearchMode: false };
-        this.generatedSections = buildLibrarySectionsFromLayoutSpecs(this.props.loadedTypesJson, this.props.layoutSpecsJson, 
-        this.props.defaultSectionString, this.props.miscSectionString);
+        this.generatedSections = buildLibrarySectionsFromLayoutSpecs(
+            this.props.loadedTypesJson, this.props.layoutSpecsJson,
+            this.props.defaultSectionString, this.props.miscSectionString);
 
         // Obtain the categories from each section to be added into the filtering options for search
         for (let section of this.generatedSections) {
             for (let childItem of section.childItems)
                 this.searchCategories.push(childItem.text);
         }
+    }
+
+    setLoadedTypesJson(loadedTypesJson: any): void {
+    }
+
+    setLayoutSpecsJson(layoutSpecsJson: any): void {
     }
 
     raiseEvent(name: string, params?: any | any[]) {
@@ -52,8 +65,8 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
     render() {
         try {
             let sections: JSX.Element[] = null;
-            const searchView = <SearchView onSearchModeChanged={this.onSearchModeChanged.bind(this)}
-                libraryContainer={this} sections={this.generatedSections} categories={this.searchCategories}/>;
+            const searchView = <SearchView onSearchModeChanged={this.onSearchModeChanged}
+                libraryContainer={this} sections={this.generatedSections} categories={this.searchCategories} />;
 
             if (!this.state.inSearchMode) {
                 let index = 0;

--- a/src/entry-point.tsx
+++ b/src/entry-point.tsx
@@ -58,25 +58,25 @@ export class LibraryController {
         this.reactor.raiseEvent(name, params);
     }
 
-    createLibraryByElementId(htmlElementId: string, layoutSpecsJson: any, loadedTypesJson: any) {
+    createLibraryByElementId(htmlElementId: string, layoutSpecsJson: any = null, loadedTypesJson: any = null) {
         let htmlElement: any;
         htmlElement = document.querySelector(htmlElementId) || document.getElementById(htmlElementId);
         if (!htmlElement) {
             throw new Error("Element " + htmlElementId + " is not defined");
         }
 
-        let libraryContainer = ReactDOM.render(<LibraryContainer
-            libraryController={this}
-            defaultSectionString={this.DefaultSectionName}
-            miscSectionString={this.MiscSectionName} />, htmlElement);
+        let libraryContainer = ReactDOM.render(this.createLibraryContainer(), htmlElement);
 
-        this.setLoadedTypesJson(loadedTypesJson);
-        this.setLayoutSpecsJson(layoutSpecsJson);
-        this.refreshLibraryView();
+        if (loadedTypesJson && (layoutSpecsJson)) {
+            this.setLoadedTypesJson(loadedTypesJson);
+            this.setLayoutSpecsJson(layoutSpecsJson);
+            this.refreshLibraryView();
+        }
+
         return libraryContainer;
     }
 
-    createLibraryContainer(layoutSpecsJson: any, loadedTypesJson: any) {
+    createLibraryContainer() {
         return (<LibraryContainer
             libraryController={this}
             defaultSectionString={this.DefaultSectionName}

--- a/src/entry-point.tsx
+++ b/src/entry-point.tsx
@@ -14,11 +14,11 @@ export function CreateLibraryController() {
 }
 
 interface SetLoadedTypesJsonFunc {
-    (loadedTypesJson: any): void;
+    (loadedTypesJson: any, append: boolean): void;
 }
 
 interface SetLayoutSpecsJsonFunc {
-    (layoutSpecsJson: any): void;
+    (layoutSpecsJson: any, append: boolean): void;
 }
 
 interface RefreshLibraryViewFunc {
@@ -68,8 +68,9 @@ export class LibraryController {
         let libraryContainer = ReactDOM.render(this.createLibraryContainer(), htmlElement);
 
         if (loadedTypesJson && (layoutSpecsJson)) {
-            this.setLoadedTypesJson(loadedTypesJson);
-            this.setLayoutSpecsJson(layoutSpecsJson);
+            let append = false; // Replace existing contents instead of appending.
+            this.setLoadedTypesJson(loadedTypesJson, append);
+            this.setLayoutSpecsJson(layoutSpecsJson, append);
             this.refreshLibraryView();
         }
 
@@ -83,15 +84,15 @@ export class LibraryController {
             miscSectionString={this.MiscSectionName} />);
     }
 
-    setLoadedTypesJson(loadedTypesJson: any): void {
+    setLoadedTypesJson(loadedTypesJson: any, append: boolean): void {
         if (this.setLoadedTypesJsonHandler) {
-            this.setLoadedTypesJsonHandler(loadedTypesJson);
+            this.setLoadedTypesJsonHandler(loadedTypesJson, append);
         }
     }
 
-    setLayoutSpecsJson(layoutSpecsJson: any): void {
+    setLayoutSpecsJson(layoutSpecsJson: any, append: boolean): void {
         if (this.setLayoutSpecsJsonHandler) {
-            this.setLayoutSpecsJsonHandler(layoutSpecsJson);
+            this.setLayoutSpecsJsonHandler(layoutSpecsJson, append);
         }
     }
 

--- a/src/entry-point.tsx
+++ b/src/entry-point.tsx
@@ -13,6 +13,18 @@ export function CreateLibraryController() {
     return new LibraryController();
 }
 
+interface SetLoadedTypesJsonFunc {
+    (loadedTypesJson: any): void;
+}
+
+interface SetLayoutSpecsJsonFunc {
+    (layoutSpecsJson: any): void;
+}
+
+interface RefreshLibraryViewFunc {
+    (): void;
+}
+
 export class LibraryController {
 
     ItemClickedEventName = "itemClicked";
@@ -21,14 +33,19 @@ export class LibraryController {
     DefaultSectionName = "default";
     MiscSectionName = "Miscellaneous";
 
-
     reactor: Reactor = null;
+    setLoadedTypesJsonHandler: SetLoadedTypesJsonFunc = null;
+    setLayoutSpecsJsonHandler: SetLayoutSpecsJsonFunc = null;
+    refreshLibraryViewHandler: RefreshLibraryViewFunc = null;
 
     constructor() {
         this.on = this.on.bind(this);
         this.raiseEvent = this.raiseEvent.bind(this);
         this.createLibraryByElementId = this.createLibraryByElementId.bind(this);
         this.createLibraryContainer = this.createLibraryContainer.bind(this);
+        this.setLoadedTypesJson = this.setLoadedTypesJson.bind(this);
+        this.setLayoutSpecsJson = this.setLayoutSpecsJson.bind(this);
+        this.refreshLibraryView = this.refreshLibraryView.bind(this);
 
         this.reactor = new Reactor();
     }
@@ -47,20 +64,40 @@ export class LibraryController {
         if (!htmlElement) {
             throw new Error("Element " + htmlElementId + " is not defined");
         }
-        return ReactDOM.render(<LibraryContainer
+
+        let libraryContainer = ReactDOM.render(<LibraryContainer
             libraryController={this}
-            loadedTypesJson={loadedTypesJson}
-            layoutSpecsJson={layoutSpecsJson}
             defaultSectionString={this.DefaultSectionName}
             miscSectionString={this.MiscSectionName} />, htmlElement);
+
+        this.setLoadedTypesJson(loadedTypesJson);
+        this.setLayoutSpecsJson(layoutSpecsJson);
+        this.refreshLibraryView();
+        return libraryContainer;
     }
 
     createLibraryContainer(layoutSpecsJson: any, loadedTypesJson: any) {
         return (<LibraryContainer
             libraryController={this}
-            layoutSpecsJson={layoutSpecsJson}
-            loadedTypesJson={loadedTypesJson}
             defaultSectionString={this.DefaultSectionName}
             miscSectionString={this.MiscSectionName} />);
+    }
+
+    setLoadedTypesJson(loadedTypesJson: any): void {
+        if (this.setLoadedTypesJsonHandler) {
+            this.setLoadedTypesJsonHandler(loadedTypesJson);
+        }
+    }
+
+    setLayoutSpecsJson(layoutSpecsJson: any): void {
+        if (this.setLayoutSpecsJsonHandler) {
+            this.setLayoutSpecsJsonHandler(layoutSpecsJson);
+        }
+    }
+
+    refreshLibraryView(): void {
+        if (this.refreshLibraryViewHandler) {
+            this.refreshLibraryViewHandler();
+        }
     }
 }

--- a/test/libraryUtilitiesTest.ts
+++ b/test/libraryUtilitiesTest.ts
@@ -21,10 +21,10 @@ function compareLayoutElements(actual: LibraryUtilities.LayoutElement, expected:
   }
 
   // Each nested child element should also match up.
-  expect(actual.childElements.length).to.equal(expected.childElements.length);
-  for (let i = 0; i < expected.childElements.length; i++) {
-    compareLayoutElements(actual.childElements[i], expected.childElements[i]);
-  }
+  // expect(actual.childElements.length).to.equal(expected.childElements.length);
+  // for (let i = 0; i < expected.childElements.length; i++) {
+  //   compareLayoutElements(actual.childElements[i], expected.childElements[i]);
+  // }
 }
 
 describe("updateSections function", function () {
@@ -84,6 +84,67 @@ describe("updateSections function", function () {
               inclusive: true
             }
           ],
+          childElements: [
+            {
+              text: "First Favourite",
+              iconUrl: "/icons/first-fav.svg",
+              elementType: "group",
+              include: [
+                {
+                  path: "Nested.Child.One",
+                  iconUrl: "/icons/Nested.Child.One.png",
+                  inclusive: true
+                },
+                {
+                  path: "Nested.Child.Two",
+                  iconUrl: "/icons/Nested.Child.Two.png",
+                  inclusive: false
+                },
+                {
+                  path: "Nested.Child.Three",
+                  iconUrl: "/icons/Nested.Child.Three.png",
+                  inclusive: true
+                }
+              ],
+              childElements: []
+            }
+          ]
+        }
+      ]
+    };
+
+    // Precondition
+    expect(oldLayoutSpecs.sections.length).to.equal(0);
+    expect(newLayoutSpecs.sections.length).to.equal(1);
+
+    LibraryUtilities.updateSections(oldLayoutSpecs, newLayoutSpecs, true);
+    expect(oldLayoutSpecs.sections.length).to.equal(1);
+
+    let rootElement: LibraryUtilities.LayoutElement = oldLayoutSpecs.sections[0];
+    compareLayoutElements(rootElement, newLayoutSpecs.sections[0]);
+  });
+
+  it("should replace all existing contents with new contents", function () {
+
+    let oldLayoutSpecs: any = {
+      sections: [
+        {
+          text: "My Favourites",
+          iconUrl: "/icons/my-fav.svg",
+          elementType: "section",
+          showHeader: true,
+          include: [
+            {
+              path: "Direct.Child.One",
+              iconUrl: "/icons/Direct.Child.One.png",
+              inclusive: false
+            },
+            {
+              path: "Direct.Child.Two",
+              iconUrl: "/icons/Direct.Child.Two.png",
+              inclusive: true
+            }
+          ],
           "childElements": [
             {
               text: "First Favourite",
@@ -113,12 +174,61 @@ describe("updateSections function", function () {
       ]
     };
 
-    // Precondition
-    expect(oldLayoutSpecs.sections.length).to.equal(0);
-    expect(newLayoutSpecs.sections.length).to.equal(1);
+    let newLayoutSpecs: any = {
+      sections: [
+        {
+          text: "My Favourites",
+          iconUrl: "/icons/my-fav-new.svg",
+          elementType: "section",
+          showHeader: false,
+          include: [
+            {
+              path: "Direct.Child.One.New",
+              iconUrl: "/icons/Direct.Child.One.New.png",
+              inclusive: true
+            },
+            {
+              path: "Direct.Child.Two.New",
+              iconUrl: "/icons/Direct.Child.Two.New.png",
+              inclusive: false
+            }
+          ],
+          childElements: [
+            {
+              text: "First Favourite",
+              iconUrl: "/icons/first-fav-new.svg",
+              elementType: "group",
+              include: [
+                {
+                  path: "Nested.Child.One.New",
+                  iconUrl: "/icons/Nested.Child.One.New.png",
+                  inclusive: false
+                },
+                {
+                  path: "Nested.Child.Two.New",
+                  iconUrl: "/icons/Nested.Child.Two.New.png",
+                  inclusive: true
+                },
+                {
+                  path: "Nested.Child.Three.New",
+                  iconUrl: "/icons/Nested.Child.Three.New.png",
+                  inclusive: false
+                }
+              ],
+              childElements: []
+            }
+          ]
+        }
+      ]
+    };
 
-    LibraryUtilities.updateSections(oldLayoutSpecs, newLayoutSpecs, true);
+    // Precondition
     expect(oldLayoutSpecs.sections.length).to.equal(1);
+    expect(newLayoutSpecs.sections.length).to.equal(1);
+    expect(oldLayoutSpecs.sections[0].text).to.equal("My Favourites");
+    expect(newLayoutSpecs.sections[0].text).to.equal("My Favourites");
+
+    LibraryUtilities.updateSections(oldLayoutSpecs, newLayoutSpecs, false);
 
     let rootElement: LibraryUtilities.LayoutElement = oldLayoutSpecs.sections[0];
     compareLayoutElements(rootElement, newLayoutSpecs.sections[0]);

--- a/test/libraryUtilitiesTest.ts
+++ b/test/libraryUtilitiesTest.ts
@@ -21,10 +21,10 @@ function compareLayoutElements(actual: LibraryUtilities.LayoutElement, expected:
   }
 
   // Each nested child element should also match up.
-  // expect(actual.childElements.length).to.equal(expected.childElements.length);
-  // for (let i = 0; i < expected.childElements.length; i++) {
-  //   compareLayoutElements(actual.childElements[i], expected.childElements[i]);
-  // }
+  expect(actual.childElements.length).to.equal(expected.childElements.length);
+  for (let i = 0; i < expected.childElements.length; i++) {
+    compareLayoutElements(actual.childElements[i], expected.childElements[i]);
+  }
 }
 
 describe("updateSections function", function () {

--- a/test/libraryUtilitiesTest.ts
+++ b/test/libraryUtilitiesTest.ts
@@ -297,6 +297,192 @@ describe("updateSections function", function () {
     compareLayoutElements(rootElement, expectedLayoutSpecs.sections[0]);
   });
 
+  it("should update existing contents including child elements", function () {
+
+    let oldLayoutSpecs: any = {
+      sections: [
+        {
+          text: "My Favourites",
+          iconUrl: "/icons/my-fav.svg",
+          elementType: "section",
+          showHeader: true,
+          include: [
+            {
+              path: "Direct.Child.One",
+              iconUrl: "/icons/Direct.Child.One.png",
+              inclusive: false
+            },
+            {
+              path: "Direct.Child.Two",
+              iconUrl: "/icons/Direct.Child.Two.png",
+              inclusive: true
+            }
+          ],
+          "childElements": [
+            {
+              text: "First Favourite",
+              iconUrl: "/icons/first-fav.svg",
+              elementType: "group",
+              include: [
+                {
+                  path: "Nested.Child.One",
+                  iconUrl: "/icons/Nested.Child.One.png",
+                  inclusive: true
+                },
+                {
+                  path: "Nested.Child.Two",
+                  iconUrl: "/icons/Nested.Child.Two.png",
+                  inclusive: false
+                },
+                {
+                  path: "Nested.Child.Three",
+                  iconUrl: "/icons/Nested.Child.Three.png",
+                  inclusive: true
+                }
+              ],
+              "childElements": []
+            }
+          ]
+        }
+      ]
+    };
+
+    let newLayoutSpecs: any = {
+      sections: [
+        {
+          text: "My Favourites",
+          iconUrl: "/icons/my-fav-new.svg",
+          elementType: "section",
+          showHeader: false,
+          include: [
+            {
+              path: "Direct.Child.One",
+              iconUrl: "/icons/Direct.Child.One.New.png",
+              inclusive: true
+            },
+            {
+              path: "Direct.Child.Two.New",
+              iconUrl: "/icons/Direct.Child.Two.New.png",
+              inclusive: false
+            }
+          ],
+          childElements: [
+            {
+              text: "Second Favourite",
+              iconUrl: "/icons/first-fav-new.svg",
+              elementType: "group",
+              include: [
+                {
+                  path: "Nested.Child.One.New",
+                  iconUrl: "/icons/Nested.Child.One.New.png",
+                  inclusive: false
+                },
+                {
+                  path: "Nested.Child.Two.New",
+                  iconUrl: "/icons/Nested.Child.Two.New.png",
+                  inclusive: true
+                },
+                {
+                  path: "Nested.Child.Three.New",
+                  iconUrl: "/icons/Nested.Child.Three.New.png",
+                  inclusive: false
+                }
+              ],
+              childElements: []
+            }
+          ]
+        }
+      ]
+    };
+
+    let expectedLayoutSpecs: any = {
+      sections: [
+        {
+          text: "My Favourites",
+          iconUrl: "/icons/my-fav-new.svg",
+          elementType: "section",
+          showHeader: false,
+          include: [
+            {
+              path: "Direct.Child.One",
+              iconUrl: "/icons/Direct.Child.One.New.png",
+              inclusive: true
+            },
+            {
+              path: "Direct.Child.Two",
+              iconUrl: "/icons/Direct.Child.Two.png",
+              inclusive: true
+            },
+            {
+              path: "Direct.Child.Two.New",
+              iconUrl: "/icons/Direct.Child.Two.New.png",
+              inclusive: false
+            }
+          ],
+          "childElements": [
+            {
+              text: "First Favourite",
+              iconUrl: "/icons/first-fav.svg",
+              elementType: "group",
+              include: [
+                {
+                  path: "Nested.Child.One",
+                  iconUrl: "/icons/Nested.Child.One.png",
+                  inclusive: true
+                },
+                {
+                  path: "Nested.Child.Two",
+                  iconUrl: "/icons/Nested.Child.Two.png",
+                  inclusive: false
+                },
+                {
+                  path: "Nested.Child.Three",
+                  iconUrl: "/icons/Nested.Child.Three.png",
+                  inclusive: true
+                }
+              ],
+              childElements: []
+            },
+            {
+              text: "Second Favourite",
+              iconUrl: "/icons/first-fav-new.svg",
+              elementType: "group",
+              include: [
+                {
+                  path: "Nested.Child.One.New",
+                  iconUrl: "/icons/Nested.Child.One.New.png",
+                  inclusive: false
+                },
+                {
+                  path: "Nested.Child.Two.New",
+                  iconUrl: "/icons/Nested.Child.Two.New.png",
+                  inclusive: true
+                },
+                {
+                  path: "Nested.Child.Three.New",
+                  iconUrl: "/icons/Nested.Child.Three.New.png",
+                  inclusive: false
+                }
+              ],
+              childElements: []
+            }
+          ]
+        }
+      ]
+    };
+
+    // Precondition
+    expect(oldLayoutSpecs.sections.length).to.equal(1);
+    expect(newLayoutSpecs.sections.length).to.equal(1);
+    expect(oldLayoutSpecs.sections[0].text).to.equal("My Favourites");
+    expect(newLayoutSpecs.sections[0].text).to.equal("My Favourites");
+
+    LibraryUtilities.updateSections(oldLayoutSpecs, newLayoutSpecs);
+
+    let rootElement: LibraryUtilities.LayoutElement = oldLayoutSpecs.sections[0];
+    compareLayoutElements(rootElement, expectedLayoutSpecs.sections[0]);
+  });
+
 });
 
 describe('listNode Class', function () {

--- a/test/libraryUtilitiesTest.ts
+++ b/test/libraryUtilitiesTest.ts
@@ -31,31 +31,31 @@ describe("updateSections function", function () {
 
   it("should throw exceptions 0", function () {
     expect(function () {
-      LibraryUtilities.updateSections(null, null, true);
+      LibraryUtilities.updateSections(null, null);
     }).to.throw("Both 'oldLayoutSpecs' and 'newLayoutSpecs' parameters must be supplied");
   });
 
   it("should throw exceptions 1", function () {
     expect(function () {
-      LibraryUtilities.updateSections({}, null, true);
+      LibraryUtilities.updateSections({}, null);
     }).to.throw("Both 'oldLayoutSpecs' and 'newLayoutSpecs' parameters must be supplied");
   });
 
   it("should throw exceptions 2", function () {
     expect(function () {
-      LibraryUtilities.updateSections(null, {}, true);
+      LibraryUtilities.updateSections(null, {});
     }).to.throw("Both 'oldLayoutSpecs' and 'newLayoutSpecs' parameters must be supplied");
   });
 
   it("should throw exceptions 3", function () {
     expect(function () {
-      LibraryUtilities.updateSections({}, {}, true);
+      LibraryUtilities.updateSections({}, {});
     }).to.throw("'oldLayoutSpecs.sections' must be a valid array");
   });
 
   it("should throw exceptions 4", function () {
     expect(function () {
-      LibraryUtilities.updateSections({ sections: [] }, {}, true);
+      LibraryUtilities.updateSections({ sections: [] }, {});
     }).to.throw("'newLayoutSpecs.sections' must be a valid array");
   });
 
@@ -117,14 +117,14 @@ describe("updateSections function", function () {
     expect(oldLayoutSpecs.sections.length).to.equal(0);
     expect(newLayoutSpecs.sections.length).to.equal(1);
 
-    LibraryUtilities.updateSections(oldLayoutSpecs, newLayoutSpecs, true);
+    LibraryUtilities.updateSections(oldLayoutSpecs, newLayoutSpecs);
     expect(oldLayoutSpecs.sections.length).to.equal(1);
 
     let rootElement: LibraryUtilities.LayoutElement = oldLayoutSpecs.sections[0];
     compareLayoutElements(rootElement, newLayoutSpecs.sections[0]);
   });
 
-  it("should replace all existing contents with new contents", function () {
+  it("should update existing contents with new contents", function () {
 
     let oldLayoutSpecs: any = {
       sections: [
@@ -183,7 +183,7 @@ describe("updateSections function", function () {
           showHeader: false,
           include: [
             {
-              path: "Direct.Child.One.New",
+              path: "Direct.Child.One",
               iconUrl: "/icons/Direct.Child.One.New.png",
               inclusive: true
             },
@@ -205,7 +205,7 @@ describe("updateSections function", function () {
                   inclusive: false
                 },
                 {
-                  path: "Nested.Child.Two.New",
+                  path: "Nested.Child.Two",
                   iconUrl: "/icons/Nested.Child.Two.New.png",
                   inclusive: true
                 },
@@ -222,16 +222,79 @@ describe("updateSections function", function () {
       ]
     };
 
+    let expectedLayoutSpecs: any = {
+      sections: [
+        {
+          text: "My Favourites",
+          iconUrl: "/icons/my-fav-new.svg",
+          elementType: "section",
+          showHeader: false,
+          include: [
+            {
+              path: "Direct.Child.One",
+              iconUrl: "/icons/Direct.Child.One.New.png",
+              inclusive: true
+            },
+            {
+              path: "Direct.Child.Two",
+              iconUrl: "/icons/Direct.Child.Two.png",
+              inclusive: true
+            },
+            {
+              path: "Direct.Child.Two.New",
+              iconUrl: "/icons/Direct.Child.Two.New.png",
+              inclusive: false
+            }
+          ],
+          "childElements": [
+            {
+              text: "First Favourite",
+              iconUrl: "/icons/first-fav-new.svg",
+              elementType: "group",
+              include: [
+                {
+                  path: "Nested.Child.One",
+                  iconUrl: "/icons/Nested.Child.One.png",
+                  inclusive: true
+                },
+                {
+                  path: "Nested.Child.Two",
+                  iconUrl: "/icons/Nested.Child.Two.New.png",
+                  inclusive: true
+                },
+                {
+                  path: "Nested.Child.Three",
+                  iconUrl: "/icons/Nested.Child.Three.png",
+                  inclusive: true
+                },
+                {
+                  path: "Nested.Child.One.New",
+                  iconUrl: "/icons/Nested.Child.One.New.png",
+                  inclusive: false
+                },
+                {
+                  path: "Nested.Child.Three.New",
+                  iconUrl: "/icons/Nested.Child.Three.New.png",
+                  inclusive: false
+                }
+              ],
+              "childElements": []
+            }
+          ]
+        }
+      ]
+    };
+
     // Precondition
     expect(oldLayoutSpecs.sections.length).to.equal(1);
     expect(newLayoutSpecs.sections.length).to.equal(1);
     expect(oldLayoutSpecs.sections[0].text).to.equal("My Favourites");
     expect(newLayoutSpecs.sections[0].text).to.equal("My Favourites");
 
-    LibraryUtilities.updateSections(oldLayoutSpecs, newLayoutSpecs, false);
+    LibraryUtilities.updateSections(oldLayoutSpecs, newLayoutSpecs);
 
     let rootElement: LibraryUtilities.LayoutElement = oldLayoutSpecs.sections[0];
-    compareLayoutElements(rootElement, newLayoutSpecs.sections[0]);
+    compareLayoutElements(rootElement, expectedLayoutSpecs.sections[0]);
   });
 
 });


### PR DESCRIPTION
### Purpose

This PR updated the APIs of `librarie.js` to allow for *loaded types* and *layout specifications* JSON objects to be specified at a later time. In another word, `LibraryContainer` can now be created without *loaded types* and *layout specs* JSON objects.

#### Here are the changes in high level:

- `updateSections` utility function and its corresponding test cases are added:

  updateSections function
  - should throw exceptions 0
  - should throw exceptions 1
  - should throw exceptions 2
  - should throw exceptions 3
  - should throw exceptions 4
  - should insert a new element when there isn't an existing one
  - should update existing contents with new contents
  - should update existing contents including child elements

- `LibraryContainer` class now exposes three new methods:

  - `setLoadedTypesJson`
  - `setLayoutSpecsJson`
  - `refreshLibraryView`

- The above new methods cannot be invoked directly through `LibraryContainer`, but should instead be done through `LibraryController` object (which as the same set of new methods)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 
@fanwgwg 
@yeexinc 

### FYIs

@ramramps 
