### PR TITLE
(Bug fix) Add renderedSections attribute

### DIFF
--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -32,6 +32,7 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
     layoutSpecsJson: any = null;
 
     generatedSections: LibraryUtilities.ItemData[] = null;
+    renderedSections: JSX.Element[] = null;
     searchCategories: string[] = [];
 
     timeout: number;
@@ -115,6 +116,9 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
         this.generatedSections = LibraryUtilities.buildLibrarySectionsFromLayoutSpecs(
             this.loadedTypesJson, this.layoutSpecsJson,
             this.props.defaultSectionString, this.props.miscSectionString);
+
+        let index = 0;
+        this.renderedSections = this.generatedSections.map(data => <LibraryItem key={index++} libraryContainer={this} data={data} />);
 
         // Obtain the categories from each section to be added into the filtering options for search
         for (let section of this.generatedSections) {
@@ -201,7 +205,7 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
 
             if (!this.state.inSearchMode) {
                 let index = 0;
-                sections = this.generatedSections.map(data => <LibraryItem key={index++} libraryContainer={this} data={data} />)
+                sections = this.renderedSections;
             }
             else {
                 if (this.state.structured) {

--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -117,6 +117,7 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
             this.loadedTypesJson, this.layoutSpecsJson,
             this.props.defaultSectionString, this.props.miscSectionString);
 
+        // Render the default view of the library
         let index = 0;
         this.renderedSections = this.generatedSections.map(data => <LibraryItem key={index++} libraryContainer={this} data={data} />);
 


### PR DESCRIPTION
This is a bug resulted from #64 

Steps to reproduce this bug:
1. Load library
2. Open search options (without doing any search) and click "Display as structured view". The default section is hidden from the view. 

This is due to `componentWillReceiveProps()` function in `LibraryItem` which sets the `expanded` state of default section to `false` when it is being re-rendered. This only happens when the state of `LibraryContainer` changes and no search has been done yet.