### PR TITLE
Reset item expansion when refreshing library view

### DIFF
--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -386,6 +386,9 @@ export function convertToDefaultSection(typeListNodes: TypeListNode[], section: 
         }
     }
 
+    // Default section is expanded by default.
+    sectionData.expanded = true;
+
     return sectionData;
 }
 
@@ -454,6 +457,9 @@ function convertToOtherSection(typeListNodes: TypeListNode[], section: LayoutEle
             }
         })
     })
+
+    // Sections other than default section are collapsed by default.
+    sectionData.expanded = false;
 
     return sectionData;
 }
@@ -586,7 +592,10 @@ export function convertToMiscSection(allNodes: TypeListNode[], section: LayoutEl
 
     _.each(unprocessedNodes, function (node) {
         buildLibraryItemsFromName(node, sectionData)
-    })
+    });
+
+    // Sections other than default section are collapsed by default.
+    sectionData.expanded = false;
 
     return sectionData;
 }

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -680,7 +680,15 @@ export function setItemStateRecursive(items: ItemData | ItemData[], visible: boo
     items = (items instanceof Array) ? items : [items];
     for (let item of items) {
         item.visible = visible;
-        item.expanded = item.itemType === "section" ? true : expanded;
+        if (item.itemType !== "section") {
+            item.expanded = expanded;
+        }
+
+        // All sections other than default section are collapsed by default.
+        if(item.itemType === "section" && item.text !== "default") {
+            item.expanded = false;
+        }
+
         setItemStateRecursive(item.childItems, visible, expanded);
     }
 }

--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -65,7 +65,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
 
         // All items are collapsed by default, except for section items
         this.state = {
-            expanded: this.props.data.itemType === "section" ? true : this.props.data.expanded
+            expanded: this.props.data.expanded
         };
     }
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -51,7 +51,7 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
             let data = new CategoryData(c, "CategoryCheckbox", true, this.onCategoriesChanged.bind(this));
             data.onOnlyButtonClicked = this.onOnlyButtonClicked.bind(this);
             this.categoryData.push(data);
-        }.bind(this))
+        }.bind(this));
     }
 
     clearInput() {
@@ -62,9 +62,12 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     }
 
     onTextChanged(event: any) {
-        let text = event.target.value.toLowerCase().replace(/ /g,'');
-        this.setState({ hasText: text.length > 0 });
-        this.props.onTextChanged(text);
+        let text = event.target.value.toLowerCase().replace(/ /g, '');
+        let hasText = text.length > 0;
+        if (hasText) {
+            this.setState({ hasText: hasText });
+            this.props.onTextChanged(text);
+        }
     }
 
     onExpandButtonClick() {


### PR DESCRIPTION
- Sections other than default section are collapsed by default.
- Section `expanded` attribute will be set when being constructed. 

### Reviewer 
@sharadkjaiswal 

### FYI
@Benglin 