### PR TITLE
Reduce font size and remove use of id in css

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -130,7 +130,7 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     render() {
         let options = null;
         let searchOptionsBtnText = this.state.hasText ? "SearchOptionsBtnEnabled" : "SearchOptionsBtnDisabled";
-        let searchOptionsBtn = <button id={searchOptionsBtnText} onClick={this.onExpandButtonClick.bind(this)}><i className="fa fa-filter"></i></button>;
+        let searchOptionsBtn = <button className={searchOptionsBtnText} onClick={this.onExpandButtonClick.bind(this)}><i className="fa fa-filter"></i></button>;
         let checkboxes: JSX.Element[] = [];
         let cancelButton: JSX.Element = null;
 

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -144,6 +144,7 @@ input {
     font-size: 11px;
     margin-left: 5px;
     display: inline-block;
+    white-space: nowrap;
 }
 
 .Arrow {

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -12,6 +12,7 @@
 body {
     font-family: "Artifakt Element", "Open Sans";
     -webkit-user-select: none;
+    font-size:13px;
     cursor: default;
 }
 
@@ -63,6 +64,7 @@ input {
     transition: 0.15s;
     background-color: #464646;
     color: #888;
+    font-size:14px;
 }
 
 .LibrarySectionHeader .LibraryItemIcon {
@@ -73,7 +75,6 @@ input {
     display: flex;
     flex-direction: row;
     align-items: center;
-    padding: 3;
     color: white;
     transition: 0.15s;
     overflow-y: hidden;
@@ -103,23 +104,23 @@ input {
 }
 
 .LibraryItemContainerSection .LibraryItemIcon {
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
     padding-right: 10px;
     -webkit-user-drag: none;
 }
 
 .LibraryItemContainerCategory .LibraryItemIcon {
-    padding: 10px;
-    width: 20px;
-    height: 20px;
+    padding: 7px 10px;
+    width: 18px;
+    height: 18px;
     -webkit-user-drag: none;
 }
 
 .LibraryItemContainerNone .LibraryItemIcon {
     padding: 2px 8px;
-    width: 32px;
-    height: 32px;
+    width: 28px;
+    height: 28px;
     -webkit-user-drag: none;
 }
 
@@ -128,43 +129,25 @@ input {
 }
 
 .LibraryItemContainerCategory .LibraryItemText {
-    font-size: 15px;
 }
 
 .LibraryItemContainerNone .LibraryItemText {
-    font-size: 13px;
-    padding: 10px 0px;
 }
 
 .LibraryItemGroupText {
-    padding: 10px 0px 10px 5px;
-    font-size: 15px;
-    color: #a9a9a9;
-}
-
-.LibraryItemMiscHeader {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    padding: 3;
-    color: white;
-}
-
-.LibraryItemMiscText {
-    padding: 10px 0px 10px 10px;
-    font-size: 15px;
+    padding: 7px 0px 7px 5px;
     color: #a9a9a9;
 }
 
 .LibraryItemParameters {
     color: #888;
-    font-size: 9pt;
+    font-size: 11px;
     margin-left: 5px;
     display: inline-block;
 }
 
 .Arrow {
-    padding: 10px 10px 10px 15px;
+    padding: 3px 6px 6px 12px;
     height: 11px;
     width: 11px;
 }
@@ -180,7 +163,7 @@ input {
 
 .ClusterLeftPane {
     display: flex;
-    padding-left: 20px;
+    padding-left: 13px;
     margin: 2px 0px;
     border-right: 2px;
     border-right-style: solid;
@@ -223,19 +206,18 @@ input {
 
 .SearchBar #SearchInputText {
     width: 100%;
-    font-size: 15px;
     padding: 2px 5px 0px 10px;
     background: none;
     outline: none;
     border: none;
 }
 
-.SearchBar #SearchInputText:focus::-webkit-input-placeholder {
+.SearchBar .SearchInputText:focus::-webkit-input-placeholder {
     opacity: 0;
 }
 
-.SearchBar #SearchOptionsBtnEnabled,
-.SearchBar #SearchOptionsBtnDisabled {
+.SearchBar .SearchOptionsBtnEnabled,
+.SearchBar .SearchOptionsBtnDisabled {
     height: 30px;
     width: 30px;
     border: none;
@@ -244,16 +226,16 @@ input {
     transition: 0.15s;
 }
 
-.SearchBar #SearchOptionsBtnEnabled {
+.SearchBar .SearchOptionsBtnEnabled {
     color: #ddd;
     transition: 0.15s;
 }
 
-.SearchBar #SearchOptionsBtnDisabled {
+.SearchBar .SearchOptionsBtnDisabled {
     color: #888;
 }
 
-.SearchBar #SearchOptionsBtnEnabled:hover {
+.SearchBar .SearchOptionsBtnEnabled:hover {
     background-color: rgba(255, 255, 255, 0.1);
     cursor: pointer;
 }
@@ -263,7 +245,7 @@ input {
 }
 
 .SearchBar .SearchOptionsContainer {
-    font-size: 13px;
+    font-size: 12px;
     color: #fff;
     margin: 0px 0px 5px 0px;
     background-color: #414141;
@@ -302,7 +284,7 @@ input {
     background-color: #414141;
     width: 100%;
     display: block;
-    padding: 5px;
+    padding: 3px;
     transition: 0.15s;
 }
 
@@ -318,7 +300,6 @@ input {
 .CheckboxLabelEnabled .CheckboxSymbol,
 .CheckboxLabelDisabled .CheckboxSymbol {
     position: absolute;
-    top: 5px;
     left: 5px;
 }
 
@@ -340,6 +321,7 @@ input {
     display: none;
     margin: 0px;
     padding: 0px;
+    font-size: 12px;
 }
 
 .CheckboxLabelEnabled .CheckboxLabelRightButton:hover {
@@ -395,7 +377,6 @@ input {
 }
 
 .SearchResultItemContainer .ItemTitle {
-    font-size: 14px;
     margin-bottom: 2px;
 }
 
@@ -408,7 +389,6 @@ input {
 .SearchResultItemContainer .ItemDetails {
     display: flex;
     align-items: center;
-    padding-top: 2px;
     font-size: 12px;
     color: #aaaaaa;
 }
@@ -427,15 +407,14 @@ input {
 
 .SearchResultItemContainer .ItemCategory {
     display: inline-block;
-    font-size: 12px;
     color: #ddd;
     padding-left: 5px;
 }
 
 .SearchResultItemContainer .ItemTypeIcon {
-    display: inline-block;
     width: 14px;
     height: 14px;
+    padding-bottom:3px;
 }
 
 .HighlightedText {


### PR DESCRIPTION
[DYN-864 Reduce individual font sizes on librarie.js](https://jira.autodesk.com/browse/DYN-864)
[DYN-865 Standardize css to use className to identify elements](https://jira.autodesk.com/browse/DYN-865)
[DYN-867 Parameters shouldn't be folded to multi-line when user shrink the library width.](https://jira.autodesk.com/browse/DYN-867)

All font sizes are reduced to 13px or lower, except for section title which is 14px.
![fontsize](https://cloud.githubusercontent.com/assets/17231814/26340747/9af6f4ca-3fc2-11e7-9e01-13de953ca3cc.PNG)

Expanded:
![fontsize2](https://cloud.githubusercontent.com/assets/17231814/26340783/d33546d4-3fc2-11e7-8be1-9f2ef34733f3.PNG)

In search:
![fontsize3](https://cloud.githubusercontent.com/assets/17231814/26340807/fbe56906-3fc2-11e7-87d1-f35850d0978e.PNG)

Side-by-side comparison with Dynamo:
![fontsize4](https://cloud.githubusercontent.com/assets/17231814/26341032/30041858-3fc4-11e7-821e-6d54362eecad.PNG)

This PR also addresses multi-line issue with parameters ([DYN-867](https://jira.autodesk.com/browse/DYN-867)): 
![fontsize5](https://cloud.githubusercontent.com/assets/17231814/26345894/f320e02a-3fd6-11e7-9e1a-6b7a23d13fb2.PNG)
