### PR TITLE
Update readme document for overriding the default search function

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,3 +247,16 @@ libController.on(libController.SectionIconClickedEventName, function (sectionTex
 });
 ```
 
+## Overriding the default search function
+
+The default search function can be overriden by setting searchLibraryItemsHandler of the controller.
+
+
+ ```js
+libController.searchLibraryItemsHandler = function (text, callback) {
+}
+```
+
+- `text`: This is the input string for searching.
+- `callback`: This is defined as SearchLibraryItemsCallbackFunc. It need to be called with the search result in a json format as defined
+in https://github.com/DynamoDS/librarie.js/blob/master/docs/loaded-data-types.md.


### PR DESCRIPTION
### Purpose

This is to update the readme document for overriding the default search function. The implementation has been done in https://github.com/DynamoDS/librarie.js/pull/81.

### FYIs
@Benglin @sharadkjaiswal @Racel 