### PR TITLE
Raise request for Library View Refresh

### DIFF
--- a/src/EventHandler.ts
+++ b/src/EventHandler.ts
@@ -23,7 +23,7 @@ export class Event {
     executeCallback(params?: any | any[]) {
         this.callbacks.forEach(callback => {
             try {
-                if (callback.length == 0) callback();
+                if (params.length == 0) callback();
                 else callback(params);
             }
             catch (e) {

--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -194,6 +194,7 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
 
     render() {
         if (!this.generatedSections) {
+            this.props.libraryController.request(this.props.libraryController.RefreshLibraryViewRequestName, function() {});
             return (<div>This is LibraryContainer</div>);
         }
 

--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -194,7 +194,8 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
 
     render() {
         if (!this.generatedSections) {
-            this.props.libraryController.request(this.props.libraryController.RefreshLibraryViewRequestName, function() {});
+            let eventName = this.props.libraryController.RefreshLibraryViewRequestName;
+            this.props.libraryController.request(eventName, null);
             return (<div>This is LibraryContainer</div>);
         }
 

--- a/src/entry-point.tsx
+++ b/src/entry-point.tsx
@@ -66,7 +66,7 @@ export class LibraryController {
 
     /**
      * This method registers the callback function when the value of a given 
-     * named variable is requested. See PackageController.request method for 
+     * named variable is requested. See LibraryController.request method for 
      * more information on each available variable name.
      * 
      * Note that if called more than once, this method replaces the original 
@@ -104,8 +104,13 @@ export class LibraryController {
 
         // Invokve handler if there's one registered.
         let requestHandler = this.requestHandler[variableName];
-        if (requestHandler && callback) {
-            let value = requestHandler(argsArray);
+        // If the a request handler was not specified, the callback 
+        // function will still be invoked with a 'null' as result.
+        let value = null; 
+        if (requestHandler) {
+            value = requestHandler(argsArray);
+        }
+        if(callback){
             callback(value);
         }
     }

--- a/src/entry-point.tsx
+++ b/src/entry-point.tsx
@@ -32,10 +32,12 @@ export class LibraryController {
     ItemMouseLeaveEventName = "itemMouseLeave";
     SectionIconClickedEventName = "sectionIconClicked";
     SearchTextUpdatedEventName = "searchTextUpdated";
+    RefreshLibraryViewRequestName = "refreshLibraryView";
     DefaultSectionName = "default";
     MiscSectionName = "Miscellaneous";
 
     reactor: Reactor = null;
+    requestHandler: any = {};
     setLoadedTypesJsonHandler: SetLoadedTypesJsonFunc = null;
     setLayoutSpecsJsonHandler: SetLayoutSpecsJsonFunc = null;
     refreshLibraryViewHandler: RefreshLibraryViewFunc = null;
@@ -43,6 +45,8 @@ export class LibraryController {
     constructor() {
         this.on = this.on.bind(this);
         this.raiseEvent = this.raiseEvent.bind(this);
+        this.registerRequestHandler = this.registerRequestHandler.bind(this);
+        this.request = this.request.bind(this);
         this.createLibraryByElementId = this.createLibraryByElementId.bind(this);
         this.createLibraryContainer = this.createLibraryContainer.bind(this);
         this.setLoadedTypesJson = this.setLoadedTypesJson.bind(this);
@@ -58,6 +62,52 @@ export class LibraryController {
 
     raiseEvent(name: string, params?: any | any[]) {
         this.reactor.raiseEvent(name, params);
+    }
+
+    /**
+     * This method registers the callback function when the value of a given 
+     * named variable is requested. See PackageController.request method for 
+     * more information on each available variable name.
+     * 
+     * Note that if called more than once, this method replaces the original 
+     * callback function with the new value.
+     * 
+     * @param {string} variableName The name of the variable.
+     * @param {Function} callback The callback function to be invoked when a 
+     * variable of the given name is queried.
+     */
+    registerRequestHandler(variableName: string, callback: Function) {
+
+        // Storing the callback function in the property map.
+        this.requestHandler[variableName] = callback;
+    }
+
+    /**
+     * External code calls this method to obtain the value of the given named 
+     * variable. The execution of this method may or may not be asynchronous 
+     * depending on the corresponding handler registered in onRequest. Once 
+     * the value of the variable is obtained, the callback function is invoked 
+     * with the value.
+     * 
+     * Possible variable and their corresponding data types are as followed:
+     * 
+     *      packageState: string
+     * 
+     * @param {string} variableName The name of the variable whose value is to 
+     * be retrieved.
+     * @param {Function} callback The callback function to be invoked when the 
+     * variable value is obtained.
+     * @param {any[]} argsArray Zero or more argument values to be passed to the 
+     * subscribed handler for this named variable.
+     */
+    request(variableName: string, callback: Function, ...argsArray: any[]) {
+
+        // Invokve handler if there's one registered.
+        let requestHandler = this.requestHandler[variableName];
+        if (requestHandler && callback) {
+            let value = requestHandler(argsArray);
+            callback(value);
+        }
     }
 
     createLibraryByElementId(htmlElementId: string, layoutSpecsJson: any = null, loadedTypesJson: any = null) {


### PR DESCRIPTION
### Purpose

This PR provides a mechanism to register request handler and raise request on library controller. When the library container doesn't have generated section, it may request for view refresh so that clients can update the `layoutSpec` as well as `loadedTypeData` and finally call `refreshLibraryView` on the library controller. This is required when ReactJS refresh the library container control [for some reason such as switching tabs in PMUI](https://github.com/DynamoDS/Dynamo/commit/eab2db8e56d8a020992df136eedb9177e358baeb), then it creates a new instance of LibraryContainer and at this moment it doesn't have the sections generated. If a client has registered a handler to serve the refresh request then the library view is refreshed properly.

### Reviewers
@Benglin 