### PR TITLE
Remove unused field that has been exposed from SearchBar

### DIFF
--- a/src/Searcher.tsx
+++ b/src/Searcher.tsx
@@ -8,7 +8,6 @@ import { SearchBar } from "./components/SearchBar";
 
 export class Searcher {
     libraryContainer: LibraryContainer = null;
-    searchInputField: HTMLInputElement = null;
     sections: LibraryUtilities.ItemData[] = [];
     categories: string[] = [];
 
@@ -18,7 +17,6 @@ export class Searcher {
     displayedCategories: string[];
 
     constructor() {
-        this.setSearchInputField = this.setSearchInputField.bind(this);
     }
 
     // To set the categories and displayedCategories
@@ -97,10 +95,5 @@ export class Searcher {
     // This function will be called to the the updated categories.
     getDisplayedCategories(): string[] {
         return this.displayedCategories;
-    }
-
-    // Obtain the search input field from SearchBar.
-    setSearchInputField(field: HTMLInputElement) {
-        this.searchInputField = field;
     }
 }

--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -338,7 +338,6 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
                 onStructuredModeChanged={this.onStructuredModeChanged}
                 onTextChanged={this.onTextChanged}
                 categories={this.searcher.getDisplayedCategories()}
-                setSearchInputField={this.searcher.setSearchInputField}
             />;
 
             return (

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -22,16 +22,11 @@ interface SearchBarExpandedFunc {
     (event: any): void;
 }
 
-interface SetSearchInputFieldFunc {
-    (field: HTMLInputElement): void
-}
-
 export interface SearchBarProps {
     onTextChanged: SearchTextChangedFunc;
     onStructuredModeChanged: StructuredModeChangedFunc;
     onDetailedModeChanged: DetailedModeChangedFunc;
     onCategoriesChanged: SearchCategoriesChangedFunc;
-    setSearchInputField: SetSearchInputFieldFunc;
     categories: string[];
 }
 
@@ -263,7 +258,7 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
                             className="SearchInputText"
                             type="input" placeholder="Search..."
                             onChange={this.onTextChanged.bind(this)}
-                            ref={(field) => { this.searchInputField = field; this.props.setSearchInputField(field) }}>
+                            ref={(field) => { this.searchInputField = field; }}>
                         </input>
                     </div>
                     {cancelButton}


### PR DESCRIPTION
### Purpose

The function interface SetSearchInputFieldFunc served to expose an internal field searchInputField and the member searchInputField in the class Searcher are not used anywhere any more. 

This is to remove them.

### Reviewers
@Benglin