### PR TITLE
Fix a bug in function removeEmptyNodes and update testcases

### DIFF
--- a/__tests__/mochatest/libraryUtilitiesTest.ts
+++ b/__tests__/mochatest/libraryUtilitiesTest.ts
@@ -108,6 +108,151 @@ describe("isValidIncludeInfo function", function () {
   });
 });
 
+describe("removeEmptyNodes function", function () {
+
+  it("should work for empty array", function () {
+    let items: LibraryUtilities.ItemData[] = [];
+    LibraryUtilities.removeEmptyNodes(items);
+    expect(items.length).to.equal(0);
+  });
+
+  it("should remove all items for an array of sections with no childItems", function () {
+    let section1 = new LibraryUtilities.ItemData("section1");
+    let section2 = new LibraryUtilities.ItemData("section2");
+    let section3 = new LibraryUtilities.ItemData("section3");
+    let items: LibraryUtilities.ItemData[] = [];
+
+    section1.itemType = "section";
+    section2.itemType = "section";
+    section3.itemType = "section";
+
+    items = [section1, section2, section3];
+
+    LibraryUtilities.removeEmptyNodes(items);
+
+    expect(items.length).to.equal(0);
+  });
+
+  it("should remove all items from an array of sections with childItems but no leaf items", function () {
+    let section1 = new LibraryUtilities.ItemData("section1");
+    let section2 = new LibraryUtilities.ItemData("section2");
+    let section3 = new LibraryUtilities.ItemData("section3");
+
+    let category11 = new LibraryUtilities.ItemData("category11");
+    let category12 = new LibraryUtilities.ItemData("category12");
+    let category21 = new LibraryUtilities.ItemData("category21");
+
+    let group111 = new LibraryUtilities.ItemData("group111");
+    let group112 = new LibraryUtilities.ItemData("group112");
+
+    section1.itemType = "section";
+    section2.itemType = "section";
+    section3.itemType = "section";
+    category11.itemType = "category";
+    category12.itemType = "category";
+    category21.itemType = "category";
+    group111.itemType = "group";
+    group112.itemType = "group";
+
+    category11.appendChild(group111);
+    category11.appendChild(group112);
+    section1.appendChild(category11);
+    section1.appendChild(category12);
+    section2.appendChild(category21);
+
+    let items: LibraryUtilities.ItemData[] = [section1, section2, section3];
+
+    LibraryUtilities.removeEmptyNodes(items);
+
+    expect(items.length).to.equal(0);
+  });
+
+  it("should remove items with no leaf items", function () {
+    let section1 = new LibraryUtilities.ItemData("section1");
+    let section2 = new LibraryUtilities.ItemData("section2");
+    let section3 = new LibraryUtilities.ItemData("section3");
+
+    let category11 = new LibraryUtilities.ItemData("category11");
+    let category12 = new LibraryUtilities.ItemData("category12");
+    let category21 = new LibraryUtilities.ItemData("category21");
+
+    let group111 = new LibraryUtilities.ItemData("group111");
+    let group112 = new LibraryUtilities.ItemData("group112");
+
+    let leaf1111 = new LibraryUtilities.ItemData("leaf1111");
+
+    section1.itemType = "section";
+    section2.itemType = "section";
+    section3.itemType = "section";
+    category11.itemType = "category";
+    category12.itemType = "category";
+    category21.itemType = "category";
+    group111.itemType = "group";
+    group112.itemType = "group";
+
+    group111.appendChild(leaf1111);
+    category11.appendChild(group111);
+    category11.appendChild(group112);
+    section1.appendChild(category11);
+    section1.appendChild(category12);
+    section2.appendChild(category21);
+
+    let items: LibraryUtilities.ItemData[] = [section1, section2, section3];
+
+    LibraryUtilities.removeEmptyNodes(items);
+
+    expect(items.length).to.equal(1);
+    expect(items[0]).to.equal(section1);
+    expect(items[0].childItems[0].childItems[0].childItems[0].text).to.equal("leaf1111");
+  });
+
+  it("should not remove items if all items have leaf items", function () {
+    let section1 = new LibraryUtilities.ItemData("section1");
+    let section2 = new LibraryUtilities.ItemData("section2");
+
+    let category11 = new LibraryUtilities.ItemData("category11");
+    let category12 = new LibraryUtilities.ItemData("category12");
+    let category21 = new LibraryUtilities.ItemData("category21");
+
+    let group111 = new LibraryUtilities.ItemData("group111");
+    let group112 = new LibraryUtilities.ItemData("group112");
+    let group211 = new LibraryUtilities.ItemData("group211");
+
+    let leaf1111 = new LibraryUtilities.ItemData("leaf1111");
+    let leaf1121 = new LibraryUtilities.ItemData("leaf1121");
+    let leaf2111 = new LibraryUtilities.ItemData("leaf2111");
+
+    section1.itemType = "section";
+    section2.itemType = "section";
+    category11.itemType = "category";
+    category12.itemType = "category";
+    category21.itemType = "category";
+    group111.itemType = "group";
+    group112.itemType = "group";
+    group211.itemType = "group";
+
+    group111.appendChild(leaf1111);
+    group112.appendChild(leaf1121);
+    group211.appendChild(leaf2111);
+    category11.appendChild(group111);
+    category11.appendChild(group112);
+    category21.appendChild(group211);
+    section1.appendChild(category11);
+    section1.appendChild(category12);
+    section2.appendChild(category21);
+
+    let items: LibraryUtilities.ItemData[] = [section1, section2];
+
+    LibraryUtilities.removeEmptyNodes(items);
+
+    expect(items.length).to.equal(2);
+    expect(items[0]).to.equal(section1);
+    expect(items[1]).to.equal(section2);
+    expect(items[0].childItems[0].childItems[0].childItems[0].text).to.equal("leaf1111");
+    expect(items[0].childItems[0].childItems[1].childItems[0].text).to.equal("leaf1121");
+    expect(items[1].childItems[0].childItems[0].childItems[0].text).to.equal("leaf2111");
+  });
+});
 
 describe("constructFromIncludeInfo function", function () {
   let includeItemPairs: LibraryUtilities.IncludeItemPair[];

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -515,7 +515,7 @@ export function removeEmptyNodes(items: ItemData[]) {
     items.forEach((item, index, items) => {
         if (item.childItems.length > 0) {
             if (removeEmptyNodes(item.childItems)) {
-                removeEmptyNodes(items);
+                removeEmptyNodes([item]);
             }
         } else if (item.itemType === "section" || item.itemType === "category" || item.itemType === "group") {
             items.splice(index, 1);

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -512,17 +512,18 @@ export function buildLibrarySectionsFromLayoutSpecs(loadedTypes: any, layoutSpec
 export function removeEmptyNodes(items: ItemData[]) {
     let itemRemoved = false;
 
-    items.forEach((item, index, items) => {
+    for (let i = 0; i < items.length; i++) {
+        let item = items[i];
         if (item.childItems.length > 0) {
             if (removeEmptyNodes(item.childItems)) {
-                removeEmptyNodes([item]);
+                i--;
             }
         } else if (item.itemType === "section" || item.itemType === "category" || item.itemType === "group") {
-            items.splice(index, 1);
+            items.splice(i, 1);
+            i--;
             itemRemoved = true;
-            removeEmptyNodes(items);
         }
-    });
+    }
 
     return itemRemoved;
 }

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -510,13 +510,21 @@ export function buildLibrarySectionsFromLayoutSpecs(loadedTypes: any, layoutSpec
 
 // Remove empty non-leaf nodes from items
 export function removeEmptyNodes(items: ItemData[]) {
+    let itemRemoved = false;
+
     items.forEach((item, index, items) => {
         if (item.childItems.length > 0) {
-            removeEmptyNodes(item.childItems);
+            if (removeEmptyNodes(item.childItems)) {
+                removeEmptyNodes(items);
+            }
         } else if (item.itemType === "section" || item.itemType === "category" || item.itemType === "group") {
             items.splice(index, 1);
+            itemRemoved = true;
+            removeEmptyNodes(items);
         }
     });
+
+    return itemRemoved;
 }
 
 /**


### PR DESCRIPTION
Function `removeEmptyNodes` will take in an array of `ItemData`, and remove all nodes that have no child items (including grandchild items).

### Reviewer
@Randy-Ma