### PR TITLE
Add more test for testing UI library

### DIFF
--- a/__tests__/Snapshottest/UIOutputComparisonTests.tsx
+++ b/__tests__/Snapshottest/UIOutputComparisonTests.tsx
@@ -53,5 +53,24 @@ describe("LibraryContainer", function () {
     let libraryItem = mount(<LibraryItem libraryContainer={libContainer} data={data} />);
     expect(toJson(libraryItem)).toMatchSnapshot();  // toJson serializes the output    
   });
+  it("Demonstrate testing UIitems loads correctly from static data", function () {
+    // This is demo test to show how to test the LibrayUI is rendered correctly
+    // Dynamo dynamcally generates the data in the libraryUI
+    // So this test does not ensure all the required items are loaded there
+    let layoutSpecsJson = require("../../docs/LayoutSpecs.json");
+    let loadedTypesJson = require("../../docs/RawTypeData.json");
+    let libController = LibraryEntryPoint.CreateLibraryController();
+    // Render with mount to test child components
+    const tree =mount(libController.createLibraryContainer()
+      ); // required to dump the html version of librarie.js
+      // create the library Controleer with the static data in the libraryui project 
+    libController.setLoadedTypesJson(loadedTypesJson, false);
+    libController.setLayoutSpecsJson(layoutSpecsJson, false);
+    libController.refreshLibraryView();
+    let libContainer = LibraryEntryPoint.CreateLibraryController();
+    // Search for all LibraryItems      
+    let text = tree.find('div.LibraryItemText');
+    expect(toJson(text)).toMatchSnapshot();
+  });
 });
 

--- a/__tests__/Snapshottest/__snapshots__/UIOutputComparisonTests.tsx.snap
+++ b/__tests__/Snapshottest/__snapshots__/UIOutputComparisonTests.tsx.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`LibraryContainer Demonstrate testing UIitems loads correctly from static data 1`] = `
+Array [
+  <div
+    className="LibraryItemText"
+>
+    Display
+</div>,
+  <div
+    className="LibraryItemText"
+>
+    Geometry
+</div>,
+  <div
+    className="LibraryItemText"
+>
+    ImportExport
+</div>,
+  <div
+    className="LibraryItemText"
+>
+    Input
+</div>,
+  <div
+    className="LibraryItemText"
+>
+    List
+</div>,
+  <div
+    className="LibraryItemText"
+>
+    Math
+</div>,
+  <div
+    className="LibraryItemText"
+>
+    Script
+</div>,
+  <div
+    className="LibraryItemText"
+>
+    String
+</div>,
+]
+`;
+
 exports[`LibraryContainer Test UI rendering of Library Item and child components 1`] = `
 <LibraryItem
   data={
@@ -16,6 +61,7 @@ exports[`LibraryContainer Test UI rendering of Library Item and child components
             "",
           ],
           "parameters": "",
+          "pathToItem": Array [],
           "showHeader": true,
           "text": "Child0",
           "visible": true,
@@ -32,6 +78,7 @@ exports[`LibraryContainer Test UI rendering of Library Item and child components
             "",
           ],
           "parameters": "",
+          "pathToItem": Array [],
           "showHeader": true,
           "text": "Child1",
           "visible": true,
@@ -47,6 +94,7 @@ exports[`LibraryContainer Test UI rendering of Library Item and child components
         "",
       ],
       "parameters": "",
+      "pathToItem": Array [],
       "showHeader": true,
       "text": "TestItem",
       "visible": true,
@@ -59,6 +107,7 @@ exports[`LibraryContainer Test UI rendering of Library Item and child components
       "ItemClickedEventName": "itemClicked",
       "ItemMouseEnterEventName": "itemMouseEnter",
       "ItemMouseLeaveEventName": "itemMouseLeave",
+      "ItemSummaryExpandedEventName": "itemSummaryExpanded",
       "MiscSectionName": "Miscellaneous",
       "SearchTextUpdatedEventName": "searchTextUpdated",
       "SectionIconClickedEventName": "sectionIconClicked",


### PR DESCRIPTION
Add more test to demonstrate loading of data from the ../../docs/LayoutSpecs.json and create snapshot test to test the rendering of UI items. This test includes all categories in libraryUI are loaded as specified in the Layoutspecs.json

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.