### PR TITLE
Update LayoutSpec

### DIFF
--- a/docs/LayoutSpecs.json
+++ b/docs/LayoutSpecs.json
@@ -1838,6 +1838,9 @@
                 "elementType": "group",
                 "include": [
                   {
+                    "path": "RevitNodes.Revit.Elements.Views.AreaPlanView"
+                  },
+                  {
                     "path": "RevitNodes.Revit.Elements.Views.AxonometricView"
                   },
                   {


### PR DESCRIPTION
Include `RevitNodes.Revit.Elements.Views.AreaPlanView` in Views category

FYI: @mjkkirschner @ramramps @alfarok @ColinDayOrg @Racel @smangarole @jnealb @sm6srw @saintentropy 

From current set-up, and node added by a third-party PR, we will need to touch this file manually. Otherwise, node will fall into wrong category:
![image](https://user-images.githubusercontent.com/3942418/30555998-5defdf08-9c77-11e7-9ba3-dca3620263cb.png)

After this change is merged, one need to build Librarie.js locally and update the min.js in DynamoProject so that this change can be consumed.
![image](https://user-images.githubusercontent.com/3942418/30556164-eb5ab7fa-9c77-11e7-9f5d-04368ac28212.png)

