### PR TITLE
Remove structured view

### DIFF
--- a/__tests__/UITests.tsx
+++ b/__tests__/UITests.tsx
@@ -261,4 +261,31 @@ describe("LibraryContainer UI", function () {
       done(); // For testframework to know when to terminate execution
     }, 500);
   });
+
+  it("search bar should not contain structured view button", function () {
+    
+        
+        let libContainer = mount(
+          libController.createLibraryContainer()
+        );
+       
+        libController.setLoadedTypesJson(loadedTypesJson, false);
+        libController.setLayoutSpecsJson(layoutSpecsJson, false);
+        libController.refreshLibraryView();
+
+        let buttons = libContainer.find('button');
+       //detail view, filter.
+        chai.expect(buttons).to.have.lengthOf(2);
+    
+        // Trigger the search so the option for detail view is enabled
+        let text = () => libContainer.find('input.SearchInputText');
+        // Set the search string 
+        text().simulate('change', { target: { value: 'Child' } });
+        chai.expect(text()).to.have.lengthOf(1);
+        // Find the buttons in the search
+        buttons = libContainer.find('button');
+       //detail view, filter, and x button//
+        chai.expect(buttons).to.have.lengthOf(3);
+        
+      });
 });

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -249,7 +249,7 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
                 <div className="LibraryHeader">
                     Library
                     <div>
-                        |{this.createFilterButton()}|{this.createStructuredButton()}|{this.createDetailedButton()}
+                        |{this.createFilterButton()}|{this.createDetailedButton()}
                     </div>
                 </div>
                 <div className="SearchInput">


### PR DESCRIPTION
This PR removes the structured search view button - it leaves all code in place and another task will be created for removing this dead code.

A UI test is also added that renders the dom and asserts the correct number of buttons exist before and after searching.