### PR TITLE
Remove icons from Geometry class sub-categories

### DIFF
--- a/__tests__/Snapshottest/__snapshots__/UIOutputComparisonTests.tsx.snap
+++ b/__tests__/Snapshottest/__snapshots__/UIOutputComparisonTests.tsx.snap
@@ -146,11 +146,6 @@ exports[`LibraryContainer Test UI rendering of Library Item and child components
         onError={[Function]}
         src="test-file-stub"
       />
-      <img
-        className="LibraryItemIcon"
-        onError={[Function]}
-        src=""
-      />
       <div
         className="LibraryItemText"
       >
@@ -182,11 +177,6 @@ exports[`LibraryContainer Test UI rendering of single component of Library Item 
       className="Arrow"
       onError={[Function]}
       src="test-file-stub"
-    />
-    <img
-      className="LibraryItemIcon"
-      onError={[Function]}
-      src=""
     />
     <div
       className="LibraryItemText"

--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -158,8 +158,9 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
     }
 
     getIconElement(): JSX.Element {
-        // Group displays only text without icon.
-        if (this.props.data.itemType !== "group" && this.props.data.itemType !== "section") {
+        let itemType = this.props.data.itemType;
+        // If the element type is a section, group, or none an icon shouldn't be displayed
+        if (itemType !== "group" && itemType !== "section" && itemType !== "none") {
             return <img
                 className={"LibraryItemIcon"}
                 src={this.props.data.iconUrl}


### PR DESCRIPTION
### Purpose

[QNTM-2675](https://jira.autodesk.com/browse/QNTM-2675)

[Supplemental Dynamo PR](https://github.com/DynamoDS/Dynamo/pull/8369)

The purpose of this PR is to remove the icons from the Geometry class sub-categories.  The icons beside the Geometry categories is confusing as they look like nodes and not sub-categories.

There are several element types in library which determine the properties each layer has.  The`none` element type contains all expandable library items that are not `categories` or `groups` (essentially all the interim dropdowns).  With this PR even if an icon url is specified it will be ignored so icons can now only be added at the top and bottom levels of the library hierarchy (`categories` and nodes `create` `action` `query`)

For more info on Element Types see the [Librarie Docs
](https://github.com/DynamoDS/librarie.js/blob/master/docs/layout-specs.md)
![image](https://user-images.githubusercontent.com/13341935/33564734-3baabf7c-d8e9-11e7-95ea-c3f293db3937.png)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@Racel 
