### PR TITLE
Remove the miscellaneous section

### DIFF
--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -507,9 +507,10 @@ export function buildLibrarySectionsFromLayoutSpecs(loadedTypes: any, layoutSpec
     constructFromIncludeInfo(sortedTypeListNodes, sortedIncludeItemPairs);
 
     // Misc section will take all unprocessed nodes
-    let miscSection = sections.find(section => section.text == miscSectionStr);
-    let unprocessedNodes = sortedTypeListNodes.filter(node => !node.processed);
-    unprocessedNodes.forEach(node => buildLibraryItemsFromName(node, miscSection));
+    //https://jira.autodesk.com/browse/QNTM-2976 - Remove the Miscellaneous section
+    // let miscSection = sections.find(section => section.text == miscSectionStr);
+    // let unprocessedNodes = sortedTypeListNodes.filter(node => !node.processed);
+    // unprocessedNodes.forEach(node => buildLibraryItemsFromName(node, miscSection));
 
     removeEmptyNodes(sections);
 


### PR DESCRIPTION
This PR is to Remove the Miscellaneous section from Librarie for Dynamo.

Task : https://jira.autodesk.com/browse/QNTM-2976

1. commented the code that adds nodes to Miscellaneous section. May be we might need it in future.
2. Layoutspec in LibrarieJS has Miscellaneous section. I did not remove that part (as this is more general and not related to any client) . But it is removed in Dynamo Librarie Layout spec. 

@alfarok @ColinDayOrg 