### PR TITLE
Send the category data to dynamo

### DIFF
--- a/__tests__/Snapshottest/__snapshots__/UIOutputComparisonTests.tsx.snap
+++ b/__tests__/Snapshottest/__snapshots__/UIOutputComparisonTests.tsx.snap
@@ -112,6 +112,7 @@ exports[`LibraryContainer Test UI rendering of Library Item and child components
       "RefreshLibraryViewRequestName": "refreshLibraryView",
       "SearchTextUpdatedEventName": "searchTextUpdated",
       "SectionIconClickedEventName": "sectionIconClicked",
+      "FilterCategoryEventName": "filterCategoryChange",
       "createLibraryByElementId": [Function],
       "createLibraryContainer": [Function],
       "on": [Function],

--- a/index.html
+++ b/index.html
@@ -68,6 +68,10 @@
             let libContainer = libController.createLibraryByElementId(
                 "libraryContainerPlaceholder", layoutSpecsJson, loadedTypesJson);
 
+            libController.on(libController.FilterCategoryEventName, function (item) {
+                console.log(item);
+            });
+
         });
     </script>
 

--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -9,6 +9,7 @@ import { LibraryController } from "../entry-point";
 import { LibraryItem } from "./LibraryItem";
 import { Searcher } from "../Searcher";
 import { SearchBar } from "./SearchBar";
+import { CategoryData } from "./SearchBar";
 import { SearchResultItem } from "./SearchResultItem";
 import * as ReactDOM from "react-dom";
 
@@ -225,10 +226,13 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
         this.setState({ detailed: value });
     }
 
-    onCategoriesChanged(categories: string[]) {
+    onCategoriesChanged(categories: string[], categoryData:CategoryData[]) {
         this.searcher.categories = categories;
         this.updateSearchResultItems(true, this.state.structured);
         this.setState({ selectedCategories: categories });
+        //This is used in Dynamo instrumenation. categoryData contains the list of all 
+        //categories in the filter with their state {checked or unchecked}
+        this.raiseEvent(this.props.libraryController.FilterCategoryEventName, categoryData);
     }
 
     onTextChanged(text: string) {

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -11,7 +11,7 @@ interface DetailedModeChangedFunc {
 }
 
 interface SearchCategoriesChangedFunc {
-    (categories: string[]): void;
+    (categories: string[], categoryData: CategoryData[]): void;
 }
 
 interface SearchTextChangedFunc {
@@ -175,7 +175,7 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
 
     setSelectedCategories(categories: string[]) {
         this.setState({ selectedCategories: categories })
-        this.props.onCategoriesChanged(categories);
+        this.props.onCategoriesChanged(categories, this.categoryData);
     }
 
     getSearchOptionsBtnClass() {
@@ -270,7 +270,7 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     }
 }
 
-class CategoryData {
+export class CategoryData {
     name: string;
     className: string;
     checked: boolean;

--- a/src/entry-point.tsx
+++ b/src/entry-point.tsx
@@ -42,6 +42,7 @@ export class LibraryController {
     SectionIconClickedEventName = "sectionIconClicked";
     SearchTextUpdatedEventName = "searchTextUpdated";
     RefreshLibraryViewRequestName = "refreshLibraryView";
+    FilterCategoryEventName = "filterCategoryChange"; 
     DefaultSectionName = "default";
     MiscSectionName = "Miscellaneous";
 


### PR DESCRIPTION
In Dynamo Instrumentation, the Filter categories are collected in 1.3 version of Library.
In the new librarieJS this information is embedded inside the JS. This PR is to add an event which sends this Filter category information to the client (Dynamo in this case).

More specific detail:
Dynamo 1.3 has this for instrumentation
```
  StringBuilder strBuilder = new StringBuilder();
            foreach (var category in SearchCategories)
            {
                strBuilder.Append(category.Name);
                strBuilder.Append(" : ");
                if (category.IsSelected)
                {
                    strBuilder.Append("Selected");
                }
                else
                {
                    strBuilder.Append("Unselected");
                }
                strBuilder.Append(", ");
            }

            Analytics.LogPiiInfo("Filter-categories", strBuilder.ToString().Trim());
```
 The above said `category` is in LibrareJS. It is the `CategoryInfo` class. So, returning that `CategoryInfo` to Dynamo, and it is easy to construct the `data:checked, data:unchecked` for instrumentation

@mjkkirschner @alfarok 