### PR TITLE
Prevent special chars from being executed in search

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -120,7 +120,7 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     }
 
     onTextChanged(event: any) {
-        let text = event.target.value.toLowerCase().replace(/ /g, '');
+        let text = event.target.value.toLowerCase().replace(/[^a-zA-Z0-9]/g, '');
         let expanded = text.length == 0 ? false : this.state.expanded;
         let hasText = text.length > 0;
 


### PR DESCRIPTION
https://jira.autodesk.com/browse/QNTM-3140

Prevent special chars from being executed in search.  Previously attempting to add a special character would cause library to freeze and would require a complete Dynamo reboot.

### Reviewers
@QilongTang 