### PR TITLE
QNTM-3710: Up and Down arrow keys are not working in library

### DIFF
--- a/src/components/LibraryContainer.tsx
+++ b/src/components/LibraryContainer.tsx
@@ -88,13 +88,11 @@ export class LibraryContainer extends React.Component<LibraryContainerProps, Lib
     }
 
     handleKeyDown(event: any) {
-        switch (event.code) {
+        switch (event.key) {
             case "ArrowUp":
-                event.preventDefault(); // Prevent arrow key from navigating around search input
                 this.updateSelectionIndex(false);
                 break;
             case "ArrowDown":
-                event.preventDefault();
                 this.updateSelectionIndex(true);
                 break;
             default:

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -90,7 +90,11 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     }
 
     handleKeyDown(event: any) {
-        switch (event.code) {
+        switch (event.key) {
+            case "ArrowUp":
+            case "ArrowDown":
+                event.preventDefault();
+               break;
             case "Escape":
                 this.clearInput();
                 break;

--- a/src/components/SearchResultItem.tsx
+++ b/src/components/SearchResultItem.tsx
@@ -60,7 +60,7 @@ export class SearchResultItem extends React.Component<SearchResultItemProps, Sea
     }
 
     handleKeyDown(event: any) {
-        switch (event.code) {
+        switch (event.key) {
             case "Enter": // Allow node creation by pressing enter key
                 if (this.state.selected) {
                     this.onItemClicked();


### PR DESCRIPTION
This PR is to address the issue of keys not being properly handled in the library when run inside of sandbox or D4R. The keys are properly handled in the librarie.js sample.

The main issue is that the switching on the key code currently is based on the event.code parameter. In the sample file this works as expected. However, in sandbox and D4R the event.code parameter is empty. There is another parameter, event.key, that holds essentially the same information and is valid for all environments. Switching to use this parameter instead causes all environments (sample, sandbox, D4R) to function as expected.

There are three places in librarie.js that currently use event.code;
- LibraryContainer: used for the arrow up and arrow down keys
- Search Bar: used for the escape key
- SearchResultItem: used for the enter key

This PR addresses all three of these areas, with the exception that the escape key is sometimes being eaten by the WPF parts of the sandbox application, and probably the D4R application as well. A separate issue will be filed for that.

All tests have passed, with the exception of two tests that are currently failing in librarie.js due to snapshot issues (see QNTM-3768). These tests fail without these changes.

@mjkkirschner 
@ramramps 
@alfarok 