### PR TITLE
Enable special characters and encode search string

### DIFF
--- a/__tests__/Snapshottest/__snapshots__/UIOutputComparisonTests.tsx.snap
+++ b/__tests__/Snapshottest/__snapshots__/UIOutputComparisonTests.tsx.snap
@@ -42,6 +42,16 @@ Array [
 >
     String
 </div>,
+  <div
+    className="LibraryItemText"
+>
+    Clockwork
+</div>,
+  <div
+    className="LibraryItemText"
+>
+    DynamoText
+</div>,
 ]
 `;
 
@@ -104,6 +114,7 @@ exports[`LibraryContainer Test UI rendering of Library Item and child components
   libraryContainer={
     LibraryController {
       "DefaultSectionName": "default",
+      "FilterCategoryEventName": "filterCategoryChange",
       "ItemClickedEventName": "itemClicked",
       "ItemMouseEnterEventName": "itemMouseEnter",
       "ItemMouseLeaveEventName": "itemMouseLeave",
@@ -112,7 +123,6 @@ exports[`LibraryContainer Test UI rendering of Library Item and child components
       "RefreshLibraryViewRequestName": "refreshLibraryView",
       "SearchTextUpdatedEventName": "searchTextUpdated",
       "SectionIconClickedEventName": "sectionIconClicked",
-      "FilterCategoryEventName": "filterCategoryChange",
       "createLibraryByElementId": [Function],
       "createLibraryContainer": [Function],
       "on": [Function],

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -124,7 +124,8 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     }
 
     onTextChanged(event: any) {
-        let text = event.target.value.toLowerCase().replace(/[^a-zA-Z0-9]/g, '');
+        // Escape special chars
+        let text = encodeURIComponent(event.target.value.toLowerCase());
         let expanded = text.length == 0 ? false : this.state.expanded;
         let hasText = text.length > 0;
 


### PR DESCRIPTION
[QNTM-4042](https://jira.autodesk.com/browse/QNTM-4042)

Supplemental [Dynamo PR](https://github.com/DynamoDS/Dynamo/pull/8776)

This PR enables all characters and spaces in search and encodes the string passed from librarie.js to Dynamo where the string is decoded and run through search.  Previously, spaces were replaced in searches because the results were not accurately returned due to the string formatting.  In a later PR all characters that were not `a-z` `0-9` were removed from the query string to prevent special characters from crashing librarie.  This PR should evade those issues.  This PR also fixes test failures that were introduced prior.

Looking forward we may want to consider modifying the search timeout logic to improve response fluidity.

## Reviewers
@mjkkirschner 

## FYI
@Racel @jnealb @smangarole 