### PR TITLE
search improvments

### DIFF
--- a/__tests__/mochatest/libraryUtilitiesTest.ts
+++ b/__tests__/mochatest/libraryUtilitiesTest.ts
@@ -1285,19 +1285,26 @@ describe('Search function', function () {
   let itemData11: LibraryUtilities.ItemData;
   let itemData12: LibraryUtilities.ItemData;
   let itemData111: LibraryUtilities.ItemData;
+  let itemData112: LibraryUtilities.ItemData;
+
 
   beforeEach(function () {
     itemData1 = new LibraryUtilities.ItemData("Points");
     itemData11 = new LibraryUtilities.ItemData("Point");
     itemData12 = new LibraryUtilities.ItemData("UV");
     itemData111 = new LibraryUtilities.ItemData("Origin");
+    itemData112 = new LibraryUtilities.ItemData(".a name with special characters$");
+
 
     itemData1.itemType = "none";
     itemData11.itemType = "none";
     itemData12.itemType = "none";
     itemData111.itemType = "none";
+    itemData112.itemType = "none";
+
 
     itemData11.appendChild(itemData111);
+    itemData11.appendChild(itemData112);
     itemData1.appendChild(itemData11);
     itemData1.appendChild(itemData12);
   });
@@ -1314,6 +1321,8 @@ describe('Search function', function () {
     expect(itemData12.expanded).to.equal(false);
     expect(itemData111.visible).to.equal(false);
     expect(itemData111.expanded).to.equal(false);
+    expect(itemData112.expanded).to.equal(false);
+
   });
 
   it('should return true when matched items are found', function () {
@@ -1333,6 +1342,7 @@ describe('Search function', function () {
     expect(itemData12.expanded).to.equal(true);
     expect(itemData111.visible).to.equal(true);
     expect(itemData111.expanded).to.equal(true);
+    expect(itemData112.expanded).to.equal(true);
   });
 
   it('should show parent item when some of its child items are matched', function () {
@@ -1347,6 +1357,8 @@ describe('Search function', function () {
     expect(itemData12.expanded).to.equal(true);
     expect(itemData111.visible).to.equal(false);
     expect(itemData111.expanded).to.equal(false);
+    expect(itemData112.expanded).to.equal(false);
+
   });
 
   it('should ignore item of type group', function () {
@@ -1362,6 +1374,25 @@ describe('Search function', function () {
     expect(itemData12.expanded).to.equal(false);
     expect(itemData111.visible).to.equal(false);
     expect(itemData111.expanded).to.equal(false);
+    expect(itemData112.expanded).to.equal(false);
+
+  });
+
+  it('should return results for search text with regex meta characters', function () {
+    let result = LibraryUtilities.search(".a name with special characters$", itemData1);
+    expect(result).to.equal(true);
+  });
+
+  it('should highlight text with regex meta characters', function () {
+    let highlightTextSpans = LibraryUtilities.getHighlightedText(
+      ".a name with special characters$",
+      ".a name with special characters$", false);
+    let highlightTextSpansMatchingDelimeter = LibraryUtilities.getHighlightedText(
+      ".a name with special characters$",
+      ".a name with special characters$", true);
+    //we should get some spans back that are not empty.
+    expect(highlightTextSpans.length).to.equal(3);
+    expect(highlightTextSpansMatchingDelimeter.length).to.equal(3);
   });
 
 });

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -324,7 +324,7 @@ function convertLayoutElementToItemData(
         if (layoutData.itemType === "section" && !layoutData.showHeader) {
             layoutData.expanded = true;
         }
-        
+
         //https://jira.autodesk.com/browse/QNTM-2975
         if (layoutData.contextData === "Add-ons") {
             layoutData.expanded = true;
@@ -523,10 +523,10 @@ export function buildLibrarySectionsFromLayoutSpecs(loadedTypes: any, layoutSpec
  * @param elements
  */
 function updateCategoryGroups(elements: LayoutElement[]) {
-    if(!elements || elements.length == 0) return;
+    if (!elements || elements.length == 0) return;
 
     //filter the section elemens
-    let sectionElements : LayoutElement[] = elements.filter((elem: LayoutElement) => {
+    let sectionElements: LayoutElement[] = elements.filter((elem: LayoutElement) => {
         return elem.elementType == "section";
     });
 
@@ -534,7 +534,7 @@ function updateCategoryGroups(elements: LayoutElement[]) {
         //get the top level category elements
         let categoryElements = section.childElements.filter((child: LayoutElement) => {
             return child.elementType == "category";
-        }); 
+        });
 
         //get the top level group elements.
         //Commented as part of the task :  https://jira.autodesk.com/browse/QNTM-2975
@@ -768,16 +768,25 @@ export function getHighlightedText(text: string, highlightedText: string, matchD
         }
     }
 
-    let regex = new RegExp(highlightedText, 'gi');
-    let segments = text.split(regex);
-    let replacements = text.match(regex);
     let spans: React.DOMElement<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>[] = [];
+    // attempt to escape regex specific characters and return no highlights if
+    // we throw an exception here.
+    try {
+        let escapedRegexCharacters = highlightedText.replace(/[*+?^$.\[\]{}()|\\\/]/g, "\\$&");
+        let regex = new RegExp(escapedRegexCharacters, 'gi');
+        let segments = text.split(regex);
+        let replacements = text.match(regex);
 
-    for (let i = 0; i < segments.length; i++) {
-        spans.push(React.DOM.span({ key: spans.length }, segments[i]));
-        if (i != segments.length - 1) {
-            spans.push(React.DOM.span({ className: "HighlightedText", key: spans.length }, replacements[i]));
+        for (let i = 0; i < segments.length; i++) {
+            spans.push(React.DOM.span({ key: spans.length }, segments[i]));
+            if (i != segments.length - 1) {
+                spans.push(React.DOM.span({ className: "HighlightedText", key: spans.length }, replacements[i]));
+            }
         }
+    }
+    catch (e) {
+        console.log((<Error>e).message);
+        return spans;
     }
 
     return spans;
@@ -803,7 +812,7 @@ export function getHighlightedText(text: string, highlightedText: string, matchD
  */
 export function findAndExpandItemByPath(pathToItem: ItemData[], allItems: ItemData[]): boolean {
 
-   let item: ItemData;
+    let item: ItemData;
     //commented the check for iconUrl. This is false only for static RawDataType files.
     item = allItems.find(item =>
         item.text == pathToItem[0].text //&& item.iconUrl == pathToItem[0].iconUrl
@@ -817,7 +826,7 @@ export function findAndExpandItemByPath(pathToItem: ItemData[], allItems: ItemDa
         item.expanded = result; // Expand only if item is found.
         return result;
     }
-    
+
 }
 
 export function sortItemsByText(items: ItemData[]): ItemData[] {

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -126,8 +126,7 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     }
 
     onTextChanged(event: any) {
-        // Escape special chars
-        let text = encodeURIComponent(event.target.value.toLowerCase());
+        let text = event.target.value.toLowerCase();
         let expanded = text.length == 0 ? false : this.state.expanded;
         let hasText = text.length > 0;
 


### PR DESCRIPTION
https://jira.autodesk.com/browse/QNTM-4324

This PR does the following:

* no longer url encodes the the search text, it's not necessary. For clients who need to do this before sending the results to their own search algorithm - it should be done in client code - See related PR in Dynamo.

* makes the `getHighLightText`  method more robust by escaping regex meta characters, and wrapping the regex matching in a try catch - if highlight text is not found or an exception is thrown, we just return an empty array of spans to highlight, and search continues to work - without the text highlight feature.

* adds tests for searching for items with special characters like " ", "." and "$"

I will send 2 more PRS - one to Dynamo and one to AVP with updated version of librariejs built from this branch.

### Reviewers:
@ramramps  @alfarok 
