### PR TITLE
Replace onMouseOver w/ onMouseEnter

### DIFF
--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -271,7 +271,7 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         if (this.props.data.showHeader) {
             return (
                 <div className={this.getLibraryItemHeaderStyle()} onClick={this.onLibraryItemClicked}
-                    onMouseOver={this.onLibraryItemMouseEnter} onMouseLeave={this.onLibraryItemMouseLeave}>
+                    onMouseEnter={this.onLibraryItemMouseEnter} onMouseLeave={this.onLibraryItemMouseLeave}>
                     {arrow}
                     {this.props.data.itemType === "section" ? null : iconElement}
                     <div className={this.getLibraryItemTextStyle()}>{this.props.data.text}</div>

--- a/src/components/SearchResultItem.tsx
+++ b/src/components/SearchResultItem.tsx
@@ -104,7 +104,7 @@ export class SearchResultItem extends React.Component<SearchResultItemProps, Sea
 
         return (
             <div className={ItemContainerStyle} onClick={this.onItemClicked.bind(this)}
-                onMouseOver={this.onLibraryItemMouseEnter.bind(this)} onMouseLeave={this.onLibraryItemMouseLeave.bind(this)}>
+                onMouseEnter={this.onLibraryItemMouseEnter.bind(this)} onMouseLeave={this.onLibraryItemMouseLeave.bind(this)}>
                 <img className={"ItemIcon"} src={iconPath} onError={this.onImageLoadFail.bind(this)} />
                 <div className={"ItemInfo"}>
                     <div className={"ItemTitle"}>{highLightedItemText}


### PR DESCRIPTION
### Purpose
Switching from `OnMouseOver` to `OnMouseEnter` because it is much more reliable for interactions with the library.  `OnMouseOver` will get called several times while moving over various child elements.  `OnMouseEnter` will only get called a single time when entering an element.  This change also corresponds to the existing code as we use `OnMouseLeave` in the opposite scenario.

### Testing
[x] AVP
[x] Dynamo

### Reviewers
@QilongTang 

### FYI
@deepakanand 