### PR TITLE
DYN-942: Actions, Query, Create icons fail to load every time a search is executed

### DIFF
--- a/src/components/SearchResultItem.tsx
+++ b/src/components/SearchResultItem.tsx
@@ -90,7 +90,7 @@ export class SearchResultItem extends React.Component<SearchResultItemProps, Sea
         let highLightedItemText = LibraryUtilities.getHighlightedText(this.props.data.text, this.props.highlightedText, true);
         let highLightedParentText = LibraryUtilities.getHighlightedText(parentText, this.props.highlightedText, false);
         let highLightedCategoryText = LibraryUtilities.getHighlightedText(categoryText, this.props.highlightedText, false);
-        let itemTypeIconPath = "src/resources/icons/library-" + this.props.data.itemType + ".svg";
+        let itemTypeIconPath = "./dist/resources/library-" + this.props.data.itemType + ".svg";
         let itemDescription: JSX.Element = null;
 
         if (this.props.detailed) {


### PR DESCRIPTION
#### Purpose

This pull request addresses JIRA task [DYN-942](https://jira.autodesk.com/browse/DYN-942)

#### This pull request does

- [x] Updates the path to node type icons in search results.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)