### PR TITLE
update styling

### DIFF
--- a/src/components/SearchResultItem.tsx
+++ b/src/components/SearchResultItem.tsx
@@ -5,12 +5,6 @@ import * as ReactDOM from "react-dom";
 import { LibraryContainer } from "./LibraryContainer";
 import * as LibraryUtilities from "../LibraryUtilities";
 
-const libraryCategoryIcons: Map<string, string> = new Map([
-    ["query", require("../resources/icons/library-query.svg")],
-    ["create", require("../resources/icons/library-create.svg")],
-    ["action", require("../resources/icons/library-action.svg")]
-]);
-
 interface ParentTextClickedFunc {
     (pathToItem: LibraryUtilities.ItemData[]): void;
 }
@@ -96,9 +90,7 @@ export class SearchResultItem extends React.Component<SearchResultItemProps, Sea
         let highLightedItemText = LibraryUtilities.getHighlightedText(this.props.data.text, this.props.highlightedText, true);
         let highLightedParentText = LibraryUtilities.getHighlightedText(parentText, this.props.highlightedText, false);
         let highLightedCategoryText = LibraryUtilities.getHighlightedText(categoryText, this.props.highlightedText, false);
-        let itemTypeIconPath = libraryCategoryIcons.has(this.props.data.itemType) 
-            ? libraryCategoryIcons.get(this.props.data.itemType)
-            : null;
+        let itemTypeIconPath = require(`../resources/icons/library-${this.props.data.itemType}.svg`)
         let itemDescription: JSX.Element = null;
 
         if (this.props.detailed) {

--- a/src/components/SearchResultItem.tsx
+++ b/src/components/SearchResultItem.tsx
@@ -5,6 +5,12 @@ import * as ReactDOM from "react-dom";
 import { LibraryContainer } from "./LibraryContainer";
 import * as LibraryUtilities from "../LibraryUtilities";
 
+const libraryCategoryIcons: Map<string, string> = new Map([
+    ["query", require("../resources/icons/library-query.svg")],
+    ["create", require("../resources/icons/library-create.svg")],
+    ["action", require("../resources/icons/library-action.svg")]
+]);
+
 interface ParentTextClickedFunc {
     (pathToItem: LibraryUtilities.ItemData[]): void;
 }
@@ -90,7 +96,9 @@ export class SearchResultItem extends React.Component<SearchResultItemProps, Sea
         let highLightedItemText = LibraryUtilities.getHighlightedText(this.props.data.text, this.props.highlightedText, true);
         let highLightedParentText = LibraryUtilities.getHighlightedText(parentText, this.props.highlightedText, false);
         let highLightedCategoryText = LibraryUtilities.getHighlightedText(categoryText, this.props.highlightedText, false);
-        let itemTypeIconPath = "./dist/resources/library-" + this.props.data.itemType + ".svg";
+        let itemTypeIconPath = libraryCategoryIcons.has(this.props.data.itemType) 
+            ? libraryCategoryIcons.get(this.props.data.itemType)
+            : null;
         let itemDescription: JSX.Element = null;
 
         if (this.props.detailed) {

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -26,6 +26,10 @@ input {
     font-family: "Artifakt Element", "Open Sans";
 }
 
+button{
+    font-size: 1rem;
+}
+
 .LibraryContainer {
     max-height: 100vh;
     display: flex;
@@ -428,8 +432,15 @@ input {
     cursor: pointer;
 }
 
+.SearchBar button.CancelButton {
+    background: transparent;
+    border: 0px;
+    outline: 0px;
+}
+
 .SearchBar button.CancelButton:hover{
     background-color: transparent;
+    cursor: pointer;
 }
 
 .SearchBar button:disabled{
@@ -490,20 +501,17 @@ input {
 
 .SearchFilterPanel .body input[type="checkbox"]{
     visibility: hidden;
-    margin: 0;
     cursor: pointer;
+    position: absolute;
 }
 
 .SearchFilterPanel .body input[type="checkbox"],
 .SearchFilterPanel .body .checkmark{
-    margin: 0;
     margin-right: 0.5rem;
 }
 
 .SearchFilterPanel .body .checkmark{
-    position: absolute;
-    top: 0;
-    left: 0;
+    position: relative;
     height: 0.8rem;
     width: 0.8rem;
     background-color: transparent;
@@ -528,13 +536,14 @@ input {
 
 /* Style the mark/indicator */ 
 .SearchFilterPanel .body .checkmark:after{
-    left: 2.5px;
-    top: -1px;
-    width: 3px;
-    height: 8px;
+    left: 0.4rem;
+    top: 0;
+    width: 0.2rem;
+    height: 0.6rem;
     border: solid black;
-    border-width: 0 2px 2px 0; 
-    transform: rotate(45deg);
+    border-width: 0 0.2rem 0.2rem 0;
+    transform: translateY(0.2rem) rotate(45deg);
+    transform-origin: top right;
 } 
 
 .SearchFilterPanel .footer{
@@ -648,16 +657,6 @@ input {
 
 .CheckboxLabelEnabled:hover .CheckboxLabelRightButton {
     display: block;
-}
-
-.SearchBar button.CancelButton {
-    background: transparent;
-    border: 0px;
-    outline: 0px;
-}
-
-.SearchBar button.CancelButton:hover {
-    cursor: pointer;
 }
 
 .SearchResultItemContainer,

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -737,9 +737,10 @@ button{
 
 .SearchResultItemContainer .ItemTypeIcon,
 .SearchResultItemContainerSelected .ItemTypeIcon {
-    width: 14px;
-    height: 14px;
-    padding-bottom: 3px;
+    width: 1rem;
+    height: 1rem;
+    margin-top: auto;
+    margin-bottom: auto;
 }
 
 .HighlightedText {

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -9,11 +9,14 @@
     src: url("fonts/ArtifaktElement-Bold.woff") format("woff");
 }
 
+html{
+    font-size: 12px;
+}
+
 body {
     font-family: "Artifakt Element", "Open Sans";
     -webkit-user-select: none;
     user-select: none;
-    font-size: 16px;
     cursor: default;
     background-color: #2a2a2a;
     color: #f5f5f5;
@@ -32,7 +35,8 @@ input {
 .LibraryItemContainer {
     flex-grow: 1;
     overflow-y: auto;
-    padding: 0 0.5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
 }
 
 .LibraryItemContainerSection {
@@ -87,17 +91,21 @@ input {
 }
 
 .LibraryItemContainerCategory > .LibraryItemHeader{
-    padding: 1rem 0;
+    padding-top: 1rem ;
+    padding-bottom: 1rem;
 }
 
 .LibraryItemContainerGroup > .LibraryItemHeader,
 .LibraryItemContainerNone > .LibraryItemHeader{
-    padding: 0.5rem 0;
+    padding-top: 0.5rem ;
+    padding-bottom: 0.5rem;
+    height: 2.5rem;
 }
 
 .LibraryItemContainerGroup,
 .LibraryItemContainerNone{
-    padding: 0 0.5rem;
+    padding-left: 0.5rem ;
+    padding-right: 0.5rem;
 }
 
 .LibraryItemHeader:hover,
@@ -123,16 +131,16 @@ input {
 }
 
 .LibraryItemContainerSection .LibraryItemIcon {
-    width: 1rem;
-    height: 1rem;
+    width: 1.2rem;
+    height: 1.2rem;
     padding-right: 10px;
     -webkit-user-drag: none;
 }
 
 .LibraryItemContainerSection .LibraryAddOnSectionIcon {
     opacity: 0.5;
-    width: 1rem;
-    height: 1rem;
+    width: 1.4rem;
+    height: 1.4rem;
     padding-right: 10px;
     -webkit-user-drag: none;
 }
@@ -145,7 +153,8 @@ input {
 }
 
 .LibraryItemContainerNone .LibraryItemIcon {
-    padding: 0 0.5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
     width: 2rem;
     height: 2rem;
     -webkit-user-drag: none;
@@ -168,12 +177,13 @@ input {
 
 .LibraryItemHeader .LibraryItemGroupText,
 .LibrarySectionHeader .LibraryItemGroupText {
-    margin: 0.5rem 0;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
 }
 
 .LibraryItemHeader .LibraryItemGroupText {
     color: #eeeeee;
-    font-size: 1.2rem;
+    font-size: 1.4rem;
 }
 
 .LibraryItemParameters {
@@ -187,7 +197,8 @@ input {
 .Arrow {
     height: 16px;
     width: 16px;
-    margin: 0 0.5rem 0 1rem
+    margin-left: 0.5rem;
+    margin-right: 1rem;
 }
 
 .CategoryArrow {
@@ -205,7 +216,7 @@ input {
     border-top: 0px;
     border-bottom: 0px;
     position: relative;
-    min-height: 3rem;
+    height: 2.5rem;
 }
 
 .LibraryItemBody > .LibraryItemContainerGroup > .LibraryItemHeader:before,
@@ -239,12 +250,14 @@ input {
 .ClusterViewContainer {
     display: flex;
     flex-direction: row;
-    margin: 1rem 0;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
 }
 
 .ClusterLeftPane {
     display: flex;
-    padding: 0 1.2rem 0 0.1rem;
+    padding-left: 1.2rem;
+    padding-right: 0.1rem;
     border-right: 2px;
     border-right-style: solid;
 }
@@ -269,30 +282,42 @@ input {
 .ClusterIcon {
     width: 1rem;
     height: 1rem;
-    padding: 0 0.5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
     -webkit-user-drag: none;
 }
 
 .SearchBar {
-    padding: 0 0.5rem;
-    margin-bottom: 1.5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+}
+
+.SearchBar.searching{
+    margin-bottom: 1rem;
 }
 
 .SearchInput {
     display: flex; 
     padding: 5px 0px;
-    margin: 0.5rem 0 1rem 0;
+    margin-top: 0.5rem;
+    margin-bottom: 0;
     width: 100%;
     position: relative;
     white-space: nowrap;
     border-bottom-color: #ffffff80;
     border-bottom-style: solid;
     border-bottom-width: 2px;
+    font-size: 1rem;
+    transition: ease-in-out 300ms;
 }
 
 .SearchInput.focus,
 .SearchInput.searching{
     border-bottom-color: #38abdf;
+}
+
+.SearchInput.searching{
+    margin-bottom: 1rem;
 }
 
 .SearchInput:after{
@@ -316,13 +341,14 @@ input {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0.8rem 0;
+    padding-top: 0.8rem;
+    padding-bottom: 0.8rem;
     color: #f5f5f5f5;
-    font-size: 1.2rem;
+    font-size: 1.4rem;
 }
 
 .SearchBar .Icon {
-    width: 1rem;
+    width: 1.2rem;
     height: 1rem;
 }
 
@@ -331,7 +357,8 @@ input {
 }
 
 .SearchInput .SearchInputText {
-    padding: 0 0.8rem;
+    padding-left: 0.8rem;
+    padding-right: 0.8rem;
     background: none;
     outline: none;
     border: none;
@@ -349,7 +376,7 @@ input {
 
 .SearchBar .SearchOptionContainer{
     display: flex;
-    height: 2rem;
+    height: 2.5rem;
     justify-content: flex-end;
     background-color: #3c3c3c;
     visibility: hidden;
@@ -414,7 +441,10 @@ input {
 }
 
 .SearchFilterPanel > div{
-    padding: 1rem;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
 }
 
 .SearchFilterPanel > div:first-child{
@@ -424,7 +454,8 @@ input {
 .SearchFilterPanel > .body{
     padding-top: 0;
     padding-bottom: 0;
-    margin: 1rem 0;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
     max-height: 400px;
     overflow-y: auto;
 }
@@ -499,11 +530,17 @@ input {
     justify-content: flex-end;
     align-items: center;
     border-top: solid #999999 1px;
-    padding: 0.5rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
 }
 
 .SearchFilterPanel .footer > * {
-    padding: 0.5rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
 }
 
 
@@ -648,11 +685,12 @@ input {
 .SearchResultItemContainer .ItemTitle,
 .SearchResultItemContainerSelected .ItemTitle {
     margin-bottom: 2px;
+    font-size: 1.2rem;
 }
 
 .SearchResultItemContainer .ItemDescription,
 .SearchResultItemContainerSelected .ItemDescription {
-    font-size: 11px;
+    font-size: 1rem;
     padding: 2px 0px;
     color: #aaa;
 }

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -39,8 +39,6 @@ button{
 .LibraryItemContainer {
     flex-grow: 1;
     overflow-y: auto;
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
 }
 
 .LibraryItemContainerSection {
@@ -68,6 +66,7 @@ button{
 .LibrarySectionHeader {
     display: flex;
     padding-top: 1rem;
+    padding-left: 1.5rem;
     margin-top: 0.5rem;
     font-size: 1.4rem;
     color: #f5f5f5f5;
@@ -97,12 +96,11 @@ button{
 .LibraryItemContainerCategory > .LibraryItemHeader{
     padding-top: 1rem ;
     padding-bottom: 1rem;
+    padding-left: 1.5rem;
 }
 
 .LibraryItemContainerGroup > .LibraryItemHeader,
 .LibraryItemContainerNone > .LibraryItemHeader{
-    padding-top: 0.5rem ;
-    padding-bottom: 0.5rem;
     height: 2.5rem;
 }
 
@@ -250,7 +248,7 @@ button{
 }
 
 .BodyIndentation {
-    padding-left: 0.4rem;
+    padding-left: 1.5rem;
 }
 
 .ClusterViewContainer {
@@ -258,6 +256,7 @@ button{
     flex-direction: row;
     margin-top: 1rem;
     margin-bottom: 1rem;
+    margin-left: -1.5rem;
 }
 
 .ClusterLeftPane {

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -666,6 +666,7 @@ button{
     padding: 3px;
     color: white;
     transition: 0.15s;
+    padding-left: 0.8rem;
 }
 
 .SearchResultItemContainerSelected {

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -35,8 +35,8 @@ input {
 .LibraryItemContainer {
     flex-grow: 1;
     overflow-y: auto;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
 }
 
 .LibraryItemContainerSection {
@@ -65,7 +65,7 @@ input {
     display: flex;
     padding-top: 1rem;
     margin-top: 0.5rem;
-    font-size: 1.2rem;
+    font-size: 1.4rem;
     color: #f5f5f5f5;
     align-items: center;
     justify-content: space-between;
@@ -167,12 +167,13 @@ input {
 
 .LibraryItemContainerCategory .LibraryItemText {
     color: #ade4de;
-    font-size: 1.2rem;
+    font-size: 1rem;
+    margin-top: 0.2rem;
 }
 
 .LibraryItemContainerNone .LibraryItemText {
     color: #c6c6c6;
-    font-size: 1.2rem;
+    font-size: 1rem;
 }
 
 .LibraryItemHeader .LibraryItemGroupText,
@@ -183,26 +184,27 @@ input {
 
 .LibraryItemHeader .LibraryItemGroupText {
     color: #eeeeee;
-    font-size: 1.4rem;
+    font-size: 1rem;
 }
 
 .LibraryItemParameters {
     color: #888;
-    font-size: 11px;
+    font-size: 1rem;
     margin-left: 5px;
     display: inline-block;
     white-space: nowrap;
 }
 
 .Arrow {
-    height: 16px;
-    width: 16px;
+    height: 1rem;
+    width: 1rem;
     margin-left: 0.5rem;
     margin-right: 1rem;
 }
 
 .CategoryArrow {
-    width: 16px;
+    width: 1rem;
+    height: 1rem;
     margin-right: 0.5rem;
     margin-top: auto;
     margin-bottom: auto;
@@ -288,8 +290,8 @@ input {
 }
 
 .SearchBar {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
 }
 
 .SearchBar.searching{
@@ -299,12 +301,10 @@ input {
 .SearchInput {
     display: flex; 
     padding: 5px 0px;
-    margin-top: 0.5rem;
-    margin-bottom: 0;
     width: 100%;
     position: relative;
     white-space: nowrap;
-    border-bottom-color: #ffffff80;
+    border-bottom-color: #dadada;
     border-bottom-style: solid;
     border-bottom-width: 2px;
     font-size: 1rem;
@@ -341,15 +341,15 @@ input {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding-top: 0.8rem;
-    padding-bottom: 0.8rem;
+    padding-top: 1.2rem;
+    padding-bottom: 1.2rem;
     color: #f5f5f5f5;
     font-size: 1.4rem;
 }
 
 .SearchBar .Icon {
     width: 1.2rem;
-    height: 1rem;
+    height: 1.2rem;
 }
 
 .SearchInp .ClearSearch{
@@ -364,7 +364,15 @@ input {
     border: none;
     width: 100%;
     color: #f5f5f5;
+    font-size: 1rem;
 }
+
+.SearchInput .SearchInputText::-webkit-input-placeholder{ color: #dadada; }
+.SearchInput .SearchInputText:-moz-placeholder{ color: #dadada; }
+.SearchInput .SearchInputText::-moz-placeholder{ color: #dadada; }
+.SearchInput .SearchInputText:-ms-input-placeholder{ color: #dadada; }
+.SearchInput .SearchInputText::-ms-input-placeholder{ color: #dadada; }
+.SearchInput .SearchInputText::placeholder{ color: #dadada; }
 
 .SearchInput .SearchInputText:focus{
     color: #38abdf;
@@ -420,6 +428,10 @@ input {
     cursor: pointer;
 }
 
+.SearchBar button.CancelButton:hover{
+    background-color: transparent;
+}
+
 .SearchBar button:disabled{
     cursor: not-allowed;
 }
@@ -436,7 +448,7 @@ input {
     color: #ffffff;
     width: 12rem;
     text-align: left;
-    font-size: 0.8rem;
+    font-size: 1rem;
     box-shadow: 0 0 1rem 0 rgba(0,0,0,0.3);
 }
 
@@ -516,8 +528,8 @@ input {
 
 /* Style the mark/indicator */ 
 .SearchFilterPanel .body .checkmark:after{
-    left: 0.25rem;
-    top: 0rem;
+    left: 2.5px;
+    top: -1px;
     width: 3px;
     height: 8px;
     border: solid black;
@@ -545,7 +557,7 @@ input {
 
 
 .SearchBar .SearchOptionsContainer {
-    font-size: 13px;
+    font-size: 1rem;
     color: #fff;
     margin: 0px 0px 5px 0px;
     background-color: #606060;
@@ -626,7 +638,7 @@ input {
     display: none;
     margin: 0px;
     padding: 0px;
-    font-size: 12px;
+    font-size: 1rem;
 }
 
 .CheckboxLabelEnabled .CheckboxLabelRightButton:hover {
@@ -699,7 +711,7 @@ input {
 .SearchResultItemContainerSelected .ItemDetails {
     display: flex;
     align-items: center;
-    font-size: 12px;
+    font-size: 1rem;
     color: #aaaaaa;
 }
 


### PR DESCRIPTION
Updating font sizes to latest design and reducing negative space between search bar and library items.

It seems to be an issue with certain machines using a different IE engine for WPF's WebBrowser component in Dynamo that don't support certain css rules (ie `padding: 1rem 2rem`), so splitting most of them using `rem` units into each `padding-{SIDE}` rule.

![library-js-update](https://user-images.githubusercontent.com/12413808/143474785-d2df98a0-20eb-4f35-a293-34e655494fd1.gif)

