### PR TITLE
DYN-4465 Lock icon dimensions with minimums

### DIFF
--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -198,15 +198,19 @@ button{
 }
 
 .Arrow {
-    height: 1rem;
     width: 1rem;
+    min-width: 1rem;
+    height: 1rem;
+    min-height: 1rem;
     margin-left: 0.5rem;
     margin-right: 1rem;
 }
 
 .CategoryArrow {
     width: 1rem;
+    min-width: 1rem;
     height: 1rem;
+    min-height: 1rem;
     margin-right: 0.5rem;
     margin-top: auto;
     margin-bottom: auto;
@@ -228,6 +232,7 @@ button{
     content: "";
     height: 1rem;
     width: 2rem;
+    min-width: 2rem;
     border: solid #d9d9d9 2px;
     border-right: 0px;
     border-top: 0px;
@@ -286,7 +291,9 @@ button{
 
 .ClusterIcon {
     width: 1rem;
+    min-width: 1rem;
     height: 1rem;
+    min-height: 1rem;
     padding-left: 0.5rem;
     padding-right: 0.5rem;
     -webkit-user-drag: none;


### PR DESCRIPTION
This PR addresses [DYN-4465](https://jira.autodesk.com/browse/DYN-4465) locking some icon sizes to prevent them from being resized when window width gets smaller.

![fix-library-icons-resize](https://user-images.githubusercontent.com/12413808/150114811-af2674bd-0eb3-43e0-a268-8a7d7ba4f8cf.gif)

