### PR TITLE
Show Add-ons section at all times.

### DIFF
--- a/__tests__/mochatest/libraryUtilitiesTest.ts
+++ b/__tests__/mochatest/libraryUtilitiesTest.ts
@@ -116,21 +116,26 @@ describe("removeEmptyNodes function", function () {
     expect(items.length).to.equal(0);
   });
 
-  it("should remove all items for an array of sections with no childItems", function () {
+  it("should remove all items for an array of sections(except Add-ons section) with no childItems", function () {
     let section1 = new LibraryUtilities.ItemData("section1");
     let section2 = new LibraryUtilities.ItemData("section2");
     let section3 = new LibraryUtilities.ItemData("section3");
+	let AddOnsSection = new LibraryUtilities.ItemData("Add-ons");
+		
     let items: LibraryUtilities.ItemData[] = [];
 
     section1.itemType = "section";
     section2.itemType = "section";
     section3.itemType = "section";
+	AddOnsSection.itemType = "section";
+	AddOnsSection.contextData = "Add-ons";
 
-    items = [section1, section2, section3];
+    items = [section1, section2, section3, AddOnsSection];
 
     LibraryUtilities.removeEmptyNodes(items);
 
-    expect(items.length).to.equal(0);
+    //The Add-ons section should be present.
+    expect(items.length).to.equal(1);
   });
 
   it("should remove all items from an array of sections with childItems but no leaf items", function () {

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -562,12 +562,11 @@ export function removeEmptyNodes(items: ItemData[]) {
             if (removeEmptyNodes(item.childItems)) {
                 i--;
             }
-        }// Do not remove the Add-ons section even when it has no child elements, as we want to show this section all times.
-		else if ( (item.itemType === "section" && item.contextData !== "Add-ons") || item.itemType === "category" || item.itemType === "group" || item.itemType === "coregroup") {
+        }else if ( (item.itemType === "section" && item.contextData !== "Add-ons") || item.itemType === "category" || item.itemType === "group" || item.itemType === "coregroup") {
             items.splice(i, 1);
             i--;
             itemRemoved = true;
-        }
+        }// Do not remove the Add-ons section even when it has no child elements, as we want to show this section all times.
     }
 
     return itemRemoved;

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -563,10 +563,11 @@ export function removeEmptyNodes(items: ItemData[]) {
                 i--;
             }
         }else if ( (item.itemType === "section" && item.contextData !== "Add-ons") || item.itemType === "category" || item.itemType === "group" || item.itemType === "coregroup") {
-            items.splice(i, 1);
+         // Do not remove the Add-ons section even when it has no child elements, as we want to show this section all times.
+			items.splice(i, 1);
             i--;
             itemRemoved = true;
-        }// Do not remove the Add-ons section even when it has no child elements, as we want to show this section all times.
+        }
     }
 
     return itemRemoved;

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -553,6 +553,7 @@ function updateCategoryGroups(elements: LayoutElement[]) {
 }
 
 // Remove empty non-leaf nodes from items
+// Ignore the Add-ons section when removing the empty non-leaf nodes because we want to show that section always. 
 export function removeEmptyNodes(items: ItemData[]) {
     let itemRemoved = false;
 

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -563,11 +563,10 @@ export function removeEmptyNodes(items: ItemData[]) {
                 i--;
             }
         }else if ( (item.itemType === "section" && item.contextData !== "Add-ons") || item.itemType === "category" || item.itemType === "group" || item.itemType === "coregroup") {
-            // Do not remove the Add-ons section even when it has no child elements, as we want to show this section all times.
-			items.splice(i, 1);
+            items.splice(i, 1);
             i--;
             itemRemoved = true;
-        }
+        }// Do not remove the Add-ons section even when it has no child elements, as we want to show this section all times.
     }
 
     return itemRemoved;

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -563,7 +563,7 @@ export function removeEmptyNodes(items: ItemData[]) {
                 i--;
             }
         }else if ( (item.itemType === "section" && item.contextData !== "Add-ons") || item.itemType === "category" || item.itemType === "group" || item.itemType === "coregroup") {
-         // Do not remove the Add-ons section even when it has no child elements, as we want to show this section all times.
+            // Do not remove the Add-ons section even when it has no child elements, as we want to show this section all times.
 			items.splice(i, 1);
             i--;
             itemRemoved = true;

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -562,7 +562,9 @@ export function removeEmptyNodes(items: ItemData[]) {
             if (removeEmptyNodes(item.childItems)) {
                 i--;
             }
-        } else if (item.itemType === "section" || item.itemType === "category" || item.itemType === "group" || item.itemType === "coregroup") {
+        } 
+		// Do not remove the Add-ons section even when it has no child elements, as we want to show this section all times.
+		else if ( (item.itemType === "section" && item.contextData !== "Add-ons") || item.itemType === "category" || item.itemType === "group" || item.itemType === "coregroup") {
             items.splice(i, 1);
             i--;
             itemRemoved = true;

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -566,7 +566,7 @@ export function removeEmptyNodes(items: ItemData[]) {
             items.splice(i, 1);
             i--;
             itemRemoved = true;
-        }// Do not remove the Add-ons section even when it has no child elements, as we want to show this section all times.
+        }// Do not remove the Add-ons section even when it has no child elements, as we want to show this section at all times.
     }
 
     return itemRemoved;

--- a/src/LibraryUtilities.ts
+++ b/src/LibraryUtilities.ts
@@ -562,8 +562,7 @@ export function removeEmptyNodes(items: ItemData[]) {
             if (removeEmptyNodes(item.childItems)) {
                 i--;
             }
-        } 
-		// Do not remove the Add-ons section even when it has no child elements, as we want to show this section all times.
+        }// Do not remove the Add-ons section even when it has no child elements, as we want to show this section all times.
 		else if ( (item.itemType === "section" && item.contextData !== "Add-ons") || item.itemType === "category" || item.itemType === "group" || item.itemType === "coregroup") {
             items.splice(i, 1);
             i--;


### PR DESCRIPTION
This PR is to address https://jira.autodesk.com/browse/DYN-2327. 

The Add-ons section header will be shown at all times. Users can import new libraries even when there are add-ons already present.

<img width="902" alt="Screen Shot 2022-02-02 at 3 46 16 AM" src="https://user-images.githubusercontent.com/43763136/152060701-68aa4d9a-6e8a-4d44-95bc-3bdc13e42090.png">

<img width="1021" alt="Screen Shot 2022-02-02 at 3 55 52 AM" src="https://user-images.githubusercontent.com/43763136/152061934-1276011d-e543-49f6-930c-0c354b7681f4.png">


@mjkkirschner @aparajit-pratap 