### PR TITLE
increase harmony timeout to 50 minutes

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -60,7 +60,7 @@ soc2:
     repository: env.HARMONY_REPO
     third_party_lib_paths:
       - "node_modules"
-    timeout: 600
+    timeout: 3000
       
 schedule:
   cron_schedule: "once_a_month"


### PR DESCRIPTION
when I have seen the harmony steps pass - it seems very variable, usually about 12 minutes or 40... I think 50 is a good point where it becomes arduous to wait any longer, and possibly useless given the high number of false positives.

For dev, maybe setting timeout very low is actually better, so having the key in the pipeline is useful in that way.

When this finally makes its way to the internal git I will keep my eye on the harmony scans. For now I have filed false positives for the false positives that were reported for my internal prs.