### PR TITLE
Use adsk-npm-license-puller (internal tool) to generate about box content

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Note: If you are having trouble running `npm install` and are outside the adsk n
  ```
 - Instructions to write a tests are found at https://github.com/DynamoDS/librarie.js/wiki/Author-and-run-tests-for-librarie.js
 
+### Generate Third Party License Info
+* to generate about box html files use `npm run generate_license`, this will output alternative about box files to `license_output/` One will contain the full transitive production dep list, the other will contain the direct production deps.
+
+
 ## Usage
 There are few ways in which library view (i.e. `LibraryContainer` object) can be constructed. Regardless of which method is used, the caller should first call `LibraryEntryPoint.CreateLibraryController` method to create `LibraryController` before obtaining an instance of `LibraryContainer` object.
 

--- a/license_output/about-box_direct.html
+++ b/license_output/about-box_direct.html
@@ -1,0 +1,141 @@
+<div>
+  <p>
+    <strong>
+        'librarieJS' &copy; 2024 Autodesk, Inc. All rights reserved.
+    </strong>
+  </p>
+  <div>
+    <p>
+      <strong>
+            All use of this Software is subject to the Autodesk terms of service accepted upon access or use of this Service or made available on the Autodesk webpage. Autodesk terms of service for Autodesk&rsquo;s various web services can be found
+            <a href="https://www.autodesk.com/company/terms-of-use/en/general-terms"> here</a>
+            .
+        </strong>
+      <br />
+      <br />
+    </p>
+    <p>
+      <strong>Privacy</strong>
+    </p>
+    <p>
+      To learn more about Autodesk&rsquo;s online and offline privacy practices, please see the
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/privacy-statement"> Autodesk Privacy Statement</a>
+      .
+    </p>
+    <p>
+      <strong>Autodesk Trademarks</strong>
+    </p>
+    <p>
+      The trademarks on the
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/intellectual-property/trademarks"> Autodesk Trademarks page</a>
+      are registered trademarks or trademarks of Autodesk, Inc., and/or its subsidiaries and/or affiliates in the USA and/or other countries.
+    </p>
+    <p>
+      All other brand names, product names or trademarks belong to their respective holders.
+    </p>
+    <p>
+      <strong>Patents</strong>
+    </p>
+    <p>
+      This Service is protected by patents listed on the
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/patents"> Autodesk Patents</a>
+      page.
+    </p>
+    <p>
+      <strong>Autodesk Cloud and Desktop Components</strong>
+    </p>
+    <p>
+      This Service may incorporate or use background Autodesk online and desktop technology components. For information about these components, see
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-cloud-platform-components"> Autodesk Cloud Platform Components</a>
+      and
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-desktop-platform-components"> Autodesk Desktop Platform Components</a>
+      .
+    </p>
+    <p>
+      <strong>
+            Third-Party Trademarks, Software Credits and Attributions
+        </strong>
+    </p><strong>core-js</strong>: Copyright (c) 2014-2022 Denis Pushkarev
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>express</strong>: Copyright (c) 2009-2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;. Copyright (c) 2013-2014 Roman Shtylman &lt;shtylman+expressjs@gmail.com&gt;. Copyright (c) 2014-2015 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>node-notifier</strong>: Copyright (c) 2017 Mikael Brevik
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>react-dom</strong>: Copyright (c) Facebook, Inc. and its affiliates.
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>react</strong>: Copyright (c) Facebook, Inc. and its affiliates.
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>underscore</strong>: Copyright (c) 2009-2020 Jeremy Ashkenas, DocumentCloud and Investigative. Reporters &amp; Editors
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+
+  </div>
+  <p>
+    IF THIS AUTODESK PRODUCT HAS BEEN LABELED AND IDENTIFIED AS CITRIX READY,
+    then this means that this Autodesk software has completed validation
+    testing with Citrix® Presentation Server™/XenApp™ software through the
+    Citrix Ready program. The Citrix Ready designation identifies products that
+    are compatible with a Citrix application delivery environment. To find out
+    more, visit www.autodesk.com/citrix. Citrix is a registered trademark and
+    the Citrix Ready logo(s) is a trademark of Citrix Systems, Inc.
+  </p>
+  <p>
+    Additional Disclaimer: Whether this Autodesk Product has been labeled and
+    identified as Citrix Ready, or this Autodesk product just works on the
+    Citrix platform but has not been labeled and identified as Citrix Ready,
+    please note that the Citrix application is network-based, and performance
+    of Autodesk Applications on the Citrix Platform may vary with network
+    performance. The Autodesk software does not include the Citrix application,
+    nor does Autodesk provide direct support for issues with the Citrix
+    application. Users should contact Citrix directly with questions related to
+    procurement and operation of the Citrix application.
+  </p>
+
+</div>

--- a/license_output/about-box_direct.html
+++ b/license_output/about-box_direct.html
@@ -1,7 +1,7 @@
 <div>
   <p>
     <strong>
-        'librarieJS' &copy; 2024 Autodesk, Inc. All rights reserved.
+        'librarieJS' &copy; 2022 Autodesk, Inc. All rights reserved.
     </strong>
   </p>
   <div>

--- a/license_output/about-box_transitive.html
+++ b/license_output/about-box_transitive.html
@@ -1,7 +1,7 @@
 <div>
   <p>
     <strong>
-        'librarieJS' &copy; 2024 Autodesk, Inc. All rights reserved.
+        'librarieJS' &copy; 2022 Autodesk, Inc. All rights reserved.
     </strong>
   </p>
   <div>

--- a/license_output/about-box_transitive.html
+++ b/license_output/about-box_transitive.html
@@ -1,0 +1,734 @@
+<div>
+  <p>
+    <strong>
+        'librarieJS' &copy; 2024 Autodesk, Inc. All rights reserved.
+    </strong>
+  </p>
+  <div>
+    <p>
+      <strong>
+            All use of this Software is subject to the Autodesk terms of service accepted upon access or use of this Service or made available on the Autodesk webpage. Autodesk terms of service for Autodesk&rsquo;s various web services can be found
+            <a href="https://www.autodesk.com/company/terms-of-use/en/general-terms"> here</a>
+            .
+        </strong>
+      <br />
+      <br />
+    </p>
+    <p>
+      <strong>Privacy</strong>
+    </p>
+    <p>
+      To learn more about Autodesk&rsquo;s online and offline privacy practices, please see the
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/privacy-statement"> Autodesk Privacy Statement</a>
+      .
+    </p>
+    <p>
+      <strong>Autodesk Trademarks</strong>
+    </p>
+    <p>
+      The trademarks on the
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/intellectual-property/trademarks"> Autodesk Trademarks page</a>
+      are registered trademarks or trademarks of Autodesk, Inc., and/or its subsidiaries and/or affiliates in the USA and/or other countries.
+    </p>
+    <p>
+      All other brand names, product names or trademarks belong to their respective holders.
+    </p>
+    <p>
+      <strong>Patents</strong>
+    </p>
+    <p>
+      This Service is protected by patents listed on the
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/patents"> Autodesk Patents</a>
+      page.
+    </p>
+    <p>
+      <strong>Autodesk Cloud and Desktop Components</strong>
+    </p>
+    <p>
+      This Service may incorporate or use background Autodesk online and desktop technology components. For information about these components, see
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-cloud-platform-components"> Autodesk Cloud Platform Components</a>
+      and
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-desktop-platform-components"> Autodesk Desktop Platform Components</a>
+      .
+    </p>
+    <p>
+      <strong>
+            Third-Party Trademarks, Software Credits and Attributions
+        </strong>
+    </p><strong>accepts</strong>: Copyright (c) 2014 Jonathan Ong &lt;me@jongleberry.com&gt;. Copyright (c) 2015 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>array-flatten</strong>: Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>body-parser</strong>: Copyright (c) 2014 Jonathan Ong &lt;me@jongleberry.com&gt;. Copyright (c) 2014-2015 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>bytes</strong>: Copyright (c) 2012-2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;. Copyright (c) 2015 Jed Watson &lt;jed.watson@me.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>content-disposition</strong>: Copyright (c) 2014-2017 Douglas Christopher Wilson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>content-type</strong>: Copyright (c) 2015 Douglas Christopher Wilson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>cookie-signature</strong>: Copyright (c) 2012 LearnBoost &amp;lt;tj@learnboost.com&amp;gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>cookie</strong>: Copyright (c) 2012-2014 Roman Shtylman &lt;shtylman@gmail.com&gt;. Copyright (c) 2015 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>core-js</strong>: Copyright (c) 2014-2022 Denis Pushkarev
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>debug</strong>: Copyright (c) 2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>depd</strong>: Copyright (c) 2014-2017 Douglas Christopher Wilson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>destroy</strong>: Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>ee-first</strong>: Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>encodeurl</strong>: Copyright (c) 2016 Douglas Christopher Wilson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>escape-html</strong>: Copyright (c) 2012-2013 TJ Holowaychuk. Copyright (c) 2015 Andreas Lubbe. Copyright (c) 2015 Tiancheng &quot;Timothy&quot; Gu
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>etag</strong>: Copyright (c) 2014-2016 Douglas Christopher Wilson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>express</strong>: Copyright (c) 2009-2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;. Copyright (c) 2013-2014 Roman Shtylman &lt;shtylman+expressjs@gmail.com&gt;. Copyright (c) 2014-2015 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>finalhandler</strong>: Copyright (c) 2014-2017 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>forwarded</strong>: Copyright (c) 2014-2017 Douglas Christopher Wilson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>fresh</strong>: Copyright (c) 2012 TJ Holowaychuk &lt;tj@vision-media.ca&gt;. Copyright (c) 2016-2017 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>growly</strong>: Copyright (C) 2014 Ibrahim Al-Rajhi &lt;abrahamalrajhi@gmail.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>http-errors</strong>: Copyright (c) 2014 Jonathan Ong me@jongleberry.com. Copyright (c) 2016 Douglas Christopher Wilson doug@somethingdoug.com
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>iconv-lite</strong>: Copyright (c) 2011 Alexander Shtuchkin
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>inherits</strong>: Copyright (c) Isaac Z. Schlueter
+    <br /><span>Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.</span>
+    <p>THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
+    <strong>ipaddr.js</strong>: Copyright (C) 2011-2017 whitequark &lt;whitequark@whitequark.org&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>is-docker</strong>: Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (https://sindresorhus.com)
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>is-wsl</strong>: Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>isexe</strong>: Copyright (c) Isaac Z. Schlueter and Contributors
+    <br /><span>Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.</span>
+    <p>THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
+    <strong>js-tokens</strong>: Copyright (c) 2014, 2015, 2016, 2017, 2018 Simon Lydell
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>loose-envify</strong>: Copyright (c) 2015 Andres Suarez &lt;zertosh@gmail.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>lru-cache</strong>: Copyright (c) Isaac Z. Schlueter and Contributors
+    <br /><span>Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.</span>
+    <p>THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
+    <strong>media-typer</strong>: Copyright (c) 2014 Douglas Christopher Wilson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>merge-descriptors</strong>: Copyright (c) 2013 Jonathan Ong &lt;me@jongleberry.com&gt;. Copyright (c) 2015 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>methods</strong>: Copyright (c) 2013-2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;. Copyright (c) 2015-2016 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>mime-db</strong>: Copyright (c) 2014 Jonathan Ong &lt;me@jongleberry.com&gt;. Copyright (c) 2015-2022 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>mime-types</strong>: Copyright (c) 2014 Jonathan Ong &lt;me@jongleberry.com&gt;. Copyright (c) 2015 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>mime</strong>: Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>ms</strong>: Copyright (c) 2016 Zeit, Inc.
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>negotiator</strong>: Copyright (c) 2012-2014 Federico Romero. Copyright (c) 2012-2014 Isaac Z. Schlueter. Copyright (c) 2014-2015 Douglas Christopher Wilson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>node-notifier</strong>: Copyright (c) 2017 Mikael Brevik
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>object-assign</strong>: Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>on-finished</strong>: Copyright (c) 2013 Jonathan Ong &lt;me@jongleberry.com&gt;. Copyright (c) 2014 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>parseurl</strong>: Copyright (c) 2014 Jonathan Ong &lt;me@jongleberry.com&gt;. Copyright (c) 2014-2017 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>path-to-regexp</strong>: Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>prop-types</strong>: Copyright (c) 2013-present, Facebook, Inc.
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>proxy-addr</strong>: Copyright (c) 2014-2016 Douglas Christopher Wilson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>qs</strong>: Copyright (c) 2014, Nathan LaFreniere and other [contributors](https://github.com/ljharb/qs/graphs/contributors). All rights reserved.
+    <br /><span>
+        Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+    </span>
+    <ol>
+      <li> Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. </li>
+      <li> Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. </li>
+      <li> Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. </li>
+    </ol>
+    <p>
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    </p>
+    <strong>range-parser</strong>: Copyright (c) 2012-2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;. Copyright (c) 2015-2016 Douglas Christopher Wilson &lt;doug@somethingdoug.com
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>raw-body</strong>: Copyright (c) 2013-2014 Jonathan Ong &lt;me@jongleberry.com&gt;. Copyright (c) 2014-2015 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>react-dom</strong>: Copyright (c) Facebook, Inc. and its affiliates.
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>react-is</strong>: Copyright (c) Facebook, Inc. and its affiliates.
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>react</strong>: Copyright (c) Facebook, Inc. and its affiliates.
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>safe-buffer</strong>: Copyright (c) Feross Aboukhadijeh
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>safer-buffer</strong>: Copyright (c) 2018 Nikita Skovoroda &lt;chalkerx@gmail.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>scheduler</strong>: Copyright (c) Facebook, Inc. and its affiliates.
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>semver</strong>: Copyright (c) Isaac Z. Schlueter and Contributors
+    <br /><span>Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.</span>
+    <p>THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
+    <strong>send</strong>: Copyright (c) 2012 TJ Holowaychuk. Copyright (c) 2014-2016 Douglas Christopher Wilson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>serve-static</strong>: Copyright (c) 2010 Sencha Inc.. Copyright (c) 2011 LearnBoost. Copyright (c) 2011 TJ Holowaychuk. Copyright (c) 2014-2016 Douglas Christopher Wilson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>setprototypeof</strong>: Copyright (c) 2015, Wes Todd
+    <br /><span>Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.</span>
+    <p>THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
+    <strong>shellwords</strong>: Copyright (C) 2011 by Jimmy Cuadra
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>statuses</strong>: Copyright (c) 2014 Jonathan Ong &lt;me@jongleberry.com&gt;. Copyright (c) 2016 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>toidentifier</strong>: Copyright (c) 2016 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>type-is</strong>: Copyright (c) 2014 Jonathan Ong &lt;me@jongleberry.com&gt;. Copyright (c) 2014-2015 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>underscore</strong>: Copyright (c) 2009-2020 Jeremy Ashkenas, DocumentCloud and Investigative. Reporters &amp; Editors
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>unpipe</strong>: Copyright (c) 2015 Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>utils-merge</strong>: Copyright (c) 2013-2017 Jared Hanson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>uuid</strong>: Copyright (c) 2010-2020 Robert Kieffer and other contributors
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>vary</strong>: Copyright (c) 2014-2017 Douglas Christopher Wilson
+    <br /><span>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    </span>
+    <p>
+      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    </p>
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </p>
+    <strong>which</strong>: Copyright (c) Isaac Z. Schlueter and Contributors
+    <br /><span>Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.</span>
+    <p>THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
+    <strong>yallist</strong>: Copyright (c) Isaac Z. Schlueter and Contributors
+    <br /><span>Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.</span>
+    <p>THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
+
+  </div>
+  <p>
+    IF THIS AUTODESK PRODUCT HAS BEEN LABELED AND IDENTIFIED AS CITRIX READY,
+    then this means that this Autodesk software has completed validation
+    testing with Citrix® Presentation Server™/XenApp™ software through the
+    Citrix Ready program. The Citrix Ready designation identifies products that
+    are compatible with a Citrix application delivery environment. To find out
+    more, visit www.autodesk.com/citrix. Citrix is a registered trademark and
+    the Citrix Ready logo(s) is a trademark of Citrix Systems, Inc.
+  </p>
+  <p>
+    Additional Disclaimer: Whether this Autodesk Product has been labeled and
+    identified as Citrix Ready, or this Autodesk product just works on the
+    Citrix platform but has not been labeled and identified as Citrix Ready,
+    please note that the Citrix application is network-based, and performance
+    of Autodesk Applications on the Citrix Platform may vary with network
+    performance. The Autodesk software does not include the Citrix application,
+    nor does Autodesk provide direct support for issues with the Citrix
+    application. Users should contact Citrix directly with questions related to
+    procurement and operation of the Citrix application.
+  </p>
+
+</div>

--- a/license_output/paos_direct.csv
+++ b/license_output/paos_direct.csv
@@ -1,0 +1,7 @@
+publisher,name,version,copyright,dateAdded,estimatedReleaseData,license,distributed
+"",core-js,"3.21.1","Copyright (c) 2014-2022 Denis Pushkarev","","",MIT,false
+"TJ Holowaychuk",express,"4.17.3","Copyright (c) 2009-2014 TJ Holowaychuk <tj@vision-media.ca>. Copyright (c) 2013-2014 Roman Shtylman <shtylman+expressjs@gmail.com>. Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"Mikael Brevik",node-notifier,"9.0.0","Copyright (c) 2017 Mikael Brevik","","",MIT,false
+"",react-dom,"16.14.0","Copyright (c) Facebook, Inc. and its affiliates.","","",MIT,false
+"",react,"16.14.0","Copyright (c) Facebook, Inc. and its affiliates.","","",MIT,false
+"Jeremy Ashkenas",underscore,"1.12.1","Copyright (c) 2009-2020 Jeremy Ashkenas, DocumentCloud and Investigative. Reporters & Editors","","",MIT,false

--- a/license_output/paos_transitive.csv
+++ b/license_output/paos_transitive.csv
@@ -1,0 +1,71 @@
+publisher,name,version,copyright,dateAdded,estimatedReleaseData,license,distributed
+"",accepts,"1.3.8","Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>. Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"Blake Embrey",array-flatten,"1.1.1","Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)","","",MIT,false
+"",body-parser,"1.19.2","Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>. Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"TJ Holowaychuk",bytes,"3.1.2","Copyright (c) 2012-2014 TJ Holowaychuk <tj@vision-media.ca>. Copyright (c) 2015 Jed Watson <jed.watson@me.com>","","",MIT,false
+"Douglas Christopher Wilson",content-disposition,"0.5.4","Copyright (c) 2014-2017 Douglas Christopher Wilson","","",MIT,false
+"Douglas Christopher Wilson",content-type,"1.0.4","Copyright (c) 2015 Douglas Christopher Wilson","","",MIT,false
+"TJ Holowaychuk",cookie-signature,"1.0.6","Copyright (c) 2012 LearnBoost &lt;tj@learnboost.com&gt;","","",MIT,false
+"Roman Shtylman",cookie,"0.4.2","Copyright (c) 2012-2014 Roman Shtylman <shtylman@gmail.com>. Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"",core-js,"3.21.1","Copyright (c) 2014-2022 Denis Pushkarev","","",MIT,false
+"TJ Holowaychuk",debug,"2.6.9","Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>","","",MIT,false
+"Douglas Christopher Wilson",depd,"1.1.2","Copyright (c) 2014-2017 Douglas Christopher Wilson","","",MIT,false
+"Jonathan Ong",destroy,"1.0.4","Copyright (c) 2014 Jonathan Ong me@jongleberry.com","","",MIT,false
+"Jonathan Ong",ee-first,"1.1.1","Copyright (c) 2014 Jonathan Ong me@jongleberry.com","","",MIT,false
+"",encodeurl,"1.0.2","Copyright (c) 2016 Douglas Christopher Wilson","","",MIT,false
+"",escape-html,"1.0.3","Copyright (c) 2012-2013 TJ Holowaychuk. Copyright (c) 2015 Andreas Lubbe. Copyright (c) 2015 Tiancheng ""Timothy"" Gu","","",MIT,false
+"",etag,"1.8.1","Copyright (c) 2014-2016 Douglas Christopher Wilson","","",MIT,false
+"TJ Holowaychuk",express,"4.17.3","Copyright (c) 2009-2014 TJ Holowaychuk <tj@vision-media.ca>. Copyright (c) 2013-2014 Roman Shtylman <shtylman+expressjs@gmail.com>. Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"Douglas Christopher Wilson",finalhandler,"1.1.2","Copyright (c) 2014-2017 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"",forwarded,"0.2.0","Copyright (c) 2014-2017 Douglas Christopher Wilson","","",MIT,false
+"TJ Holowaychuk",fresh,"0.5.2","Copyright (c) 2012 TJ Holowaychuk <tj@vision-media.ca>. Copyright (c) 2016-2017 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"Ibrahim Al-Rajhi",growly,"1.3.0","Copyright (C) 2014 Ibrahim Al-Rajhi <abrahamalrajhi@gmail.com>","","",MIT,false
+"Jonathan Ong",http-errors,"1.8.1","Copyright (c) 2014 Jonathan Ong me@jongleberry.com. Copyright (c) 2016 Douglas Christopher Wilson doug@somethingdoug.com","","",MIT,false
+"Alexander Shtuchkin",iconv-lite,"0.4.24","Copyright (c) 2011 Alexander Shtuchkin","","",MIT,false
+"",inherits,"2.0.4","Copyright (c) Isaac Z. Schlueter","","",ISC,false
+whitequark,"ipaddr.js","1.9.1","Copyright (C) 2011-2017 whitequark <whitequark@whitequark.org>","","",MIT,false
+"Sindre Sorhus",is-docker,"2.2.1","Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)","","",MIT,false
+"Sindre Sorhus",is-wsl,"2.2.0","Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)","","",MIT,false
+"Isaac Z. Schlueter",isexe,"2.0.0","Copyright (c) Isaac Z. Schlueter and Contributors","","",ISC,false
+"Simon Lydell",js-tokens,"4.0.0","Copyright (c) 2014, 2015, 2016, 2017, 2018 Simon Lydell","","",MIT,false
+"Andres Suarez",loose-envify,"1.4.0","Copyright (c) 2015 Andres Suarez <zertosh@gmail.com>","","",MIT,false
+"Isaac Z. Schlueter",lru-cache,"6.0.0","Copyright (c) Isaac Z. Schlueter and Contributors","","",ISC,false
+"Douglas Christopher Wilson",media-typer,"0.3.0","Copyright (c) 2014 Douglas Christopher Wilson","","",MIT,false
+"Jonathan Ong",merge-descriptors,"1.0.1","Copyright (c) 2013 Jonathan Ong <me@jongleberry.com>. Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"",methods,"1.1.2","Copyright (c) 2013-2014 TJ Holowaychuk <tj@vision-media.ca>. Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"",mime-db,"1.52.0","Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>. Copyright (c) 2015-2022 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"",mime-types,"2.1.35","Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>. Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"Robert Kieffer",mime,"1.6.0","Copyright (c) 2010 Benjamin Thomas, Robert Kieffer","","",MIT,false
+"",ms,"2.0.0","Copyright (c) 2016 Zeit, Inc.","","",MIT,false
+"",negotiator,"0.6.3","Copyright (c) 2012-2014 Federico Romero. Copyright (c) 2012-2014 Isaac Z. Schlueter. Copyright (c) 2014-2015 Douglas Christopher Wilson","","",MIT,false
+"Mikael Brevik",node-notifier,"9.0.0","Copyright (c) 2017 Mikael Brevik","","",MIT,false
+"Sindre Sorhus",object-assign,"4.1.1","Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)","","",MIT,false
+"",on-finished,"2.3.0","Copyright (c) 2013 Jonathan Ong <me@jongleberry.com>. Copyright (c) 2014 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"",parseurl,"1.3.3","Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>. Copyright (c) 2014-2017 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"",path-to-regexp,"0.1.7","Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)","","",MIT,false
+"",prop-types,"15.7.2","Copyright (c) 2013-present, Facebook, Inc.","","",MIT,false
+"Douglas Christopher Wilson",proxy-addr,"2.0.7","Copyright (c) 2014-2016 Douglas Christopher Wilson","","",MIT,false
+"",qs,"6.9.7","Copyright (c) 2014, Nathan LaFreniere and other [contributors](https://github.com/ljharb/qs/graphs/contributors). All rights reserved.","","",BSD-3-Clause,false
+"TJ Holowaychuk",range-parser,"1.2.1","Copyright (c) 2012-2014 TJ Holowaychuk <tj@vision-media.ca>. Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com","","",MIT,false
+"Jonathan Ong",raw-body,"2.4.3","Copyright (c) 2013-2014 Jonathan Ong <me@jongleberry.com>. Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"",react-dom,"16.14.0","Copyright (c) Facebook, Inc. and its affiliates.","","",MIT,false
+"",react-is,"16.13.1","Copyright (c) Facebook, Inc. and its affiliates.","","",MIT,false
+"",react,"16.14.0","Copyright (c) Facebook, Inc. and its affiliates.","","",MIT,false
+"Feross Aboukhadijeh",safe-buffer,"5.2.1","Copyright (c) Feross Aboukhadijeh","","",MIT,false
+"Nikita Skovoroda",safer-buffer,"2.1.2","Copyright (c) 2018 Nikita Skovoroda <chalkerx@gmail.com>","","",MIT,false
+"",scheduler,"0.19.1","Copyright (c) Facebook, Inc. and its affiliates.","","",MIT,false
+"",semver,"7.3.5","Copyright (c) Isaac Z. Schlueter and Contributors","","",ISC,false
+"TJ Holowaychuk",send,"0.17.2","Copyright (c) 2012 TJ Holowaychuk. Copyright (c) 2014-2016 Douglas Christopher Wilson","","",MIT,false
+"Douglas Christopher Wilson",serve-static,"1.14.2","Copyright (c) 2010 Sencha Inc.. Copyright (c) 2011 LearnBoost. Copyright (c) 2011 TJ Holowaychuk. Copyright (c) 2014-2016 Douglas Christopher Wilson","","",MIT,false
+"Wes Todd",setprototypeof,"1.2.0","Copyright (c) 2015, Wes Todd","","",ISC,false
+"Jimmy Cuadra",shellwords,"0.1.1","Copyright (C) 2011 by Jimmy Cuadra","","",MIT,false
+"",statuses,"1.5.0","Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>. Copyright (c) 2016 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"Douglas Christopher Wilson",toidentifier,"1.0.1","Copyright (c) 2016 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"",type-is,"1.6.18","Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>. Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"Jeremy Ashkenas",underscore,"1.12.1","Copyright (c) 2009-2020 Jeremy Ashkenas, DocumentCloud and Investigative. Reporters & Editors","","",MIT,false
+"Douglas Christopher Wilson",unpipe,"1.0.0","Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>","","",MIT,false
+"Jared Hanson",utils-merge,"1.0.1","Copyright (c) 2013-2017 Jared Hanson","","",MIT,false
+"",uuid,"8.3.2","Copyright (c) 2010-2020 Robert Kieffer and other contributors","","",MIT,false
+"Douglas Christopher Wilson",vary,"1.1.2","Copyright (c) 2014-2017 Douglas Christopher Wilson","","",MIT,false
+"Isaac Z. Schlueter",which,"2.0.2","Copyright (c) Isaac Z. Schlueter and Contributors","","",ISC,false
+"Isaac Z. Schlueter",yallist,"4.0.0","Copyright (c) Isaac Z. Schlueter and Contributors","","",ISC,false

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "underscore": "^1.12.1"
       },
       "devDependencies": {
-        "@adsk/adsk-npm-license-puller": "^3.7.0",
         "@types/chai": "^3.4.35",
         "@types/enzyme": "^3.10.8",
         "@types/enzyme-adapter-react-16": "^1.0.6",
@@ -47,22 +46,6 @@
         "webpack": "^4.46.0",
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-cli": "^4.9.2"
-      }
-    },
-    "node_modules/@adsk/adsk-npm-license-puller": {
-      "version": "3.7.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/@adsk/adsk-npm-license-puller/-/@adsk/adsk-npm-license-puller-3.7.0.tgz",
-      "integrity": "sha512-YrNhVGRHa+Zmn47MXAWw2OIbE3ZWjiogiWmvYyVfLJakQUZLOTp/MFVjMb3Hl7+8Cwo8Qx0v5SxdhxBxSVjpSA==",
-      "dev": true,
-      "dependencies": {
-        "command-line-args": "^5.1.1",
-        "convert-array-to-csv": "^1.0.9",
-        "html-entities": "^1.2.1",
-        "license-checker-rseidelsohn": "^3.1.0",
-        "pretty": "^2.0.0"
-      },
-      "bin": {
-        "adsk-npm-license-puller": "bin/index.js"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3971,12 +3954,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/accepts/-/accepts-1.3.8.tgz",
@@ -4216,29 +4193,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/array-filter": {
       "version": "1.0.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/array-filter/-/array-filter-1.0.0.tgz",
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
       "dev": true
-    },
-    "node_modules/array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -4285,12 +4244,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true
     },
     "node_modules/asn1.js": {
       "version": "5.4.1",
@@ -5568,21 +5521,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
-      "dev": true,
-      "dependencies": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/commander/-/commander-2.20.3.tgz",
@@ -5624,42 +5562,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/condense-newlines": {
-      "version": "0.2.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/condense-newlines/-/condense-newlines-0.2.1.tgz",
-      "integrity": "sha512-P7X+QL9Hb9B/c8HI5BFFKmjgBu2XpQuF98WZ9XkO+dBGgk5XgwiQz7o1SmpglNWId3581UcS0SFAWfoIhMHPfg==",
-      "dev": true,
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-whitespace": "^0.3.0",
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/condense-newlines/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dev": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/config-chain": {
-      "version": "1.1.13",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/config-chain/-/config-chain-1.1.13.tgz",
-      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-      "dev": true,
-      "dependencies": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
       }
     },
     "node_modules/console-browserify": {
@@ -5715,12 +5617,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/convert-array-to-csv": {
-      "version": "1.0.12",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/convert-array-to-csv/-/convert-array-to-csv-1.0.12.tgz",
-      "integrity": "sha512-1PcSrmuJ+IhwTQ76ivWdMrQmM68gLbyaM44aXUIfbyPehvzPHdsv4iJh5yZtDN/G1zIhECsQMvzLpGxh2+pmkA==",
-      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "1.7.0",
@@ -6036,15 +5932,6 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/debuglog": {
-      "version": "1.0.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/debuglog/-/debuglog-1.0.1.tgz",
-      "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/decimal.js": {
       "version": "10.3.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/decimal.js/-/decimal.js-10.3.1.tgz",
@@ -6165,16 +6052,6 @@
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "license": "MIT"
-    },
-    "node_modules/dezalgo": {
-      "version": "1.0.4",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/dezalgo/-/dezalgo-1.0.4.tgz",
-      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
-      "dev": true,
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
     },
     "node_modules/diff-sequences": {
       "version": "27.5.1",
@@ -6299,21 +6176,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
-      }
-    },
-    "node_modules/editorconfig": {
-      "version": "0.15.3",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/editorconfig/-/editorconfig-0.15.3.tgz",
-      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^2.19.0",
-        "lru-cache": "^4.1.5",
-        "semver": "^5.6.0",
-        "sigmund": "^1.0.1"
-      },
-      "bin": {
-        "editorconfig": "bin/editorconfig"
       }
     },
     "node_modules/ee-first": {
@@ -7267,18 +7129,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dev": true,
-      "dependencies": {
-        "array-back": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/find-up/-/find-up-4.1.0.tgz",
@@ -7782,36 +7632,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/hosted-git-info/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/html-element-map": {
       "version": "1.2.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/html-element-map/-/html-element-map-1.2.0.tgz",
@@ -7823,12 +7643,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/html-entities": {
-      "version": "1.4.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/html-entities/-/html-entities-1.4.0.tgz",
-      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
-      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -8084,12 +7898,6 @@
       "version": "2.0.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "node_modules/internal-slot": {
@@ -8510,15 +8318,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-whitespace": {
-      "version": "0.3.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/is-whitespace/-/is-whitespace-0.3.0.tgz",
-      "integrity": "sha512-RydPhl4S6JwAyj0JJjshWJEFG6hNye3pZFBRZaTUfZFwGHxzppNaNOVgQuS/E/SlhrApuMXrpnK1EEIXfdo3Dg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-windows": {
@@ -11303,78 +11102,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js-beautify": {
-      "version": "1.14.6",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/js-beautify/-/js-beautify-1.14.6.tgz",
-      "integrity": "sha512-GfofQY5zDp+cuHc+gsEXKPpNw2KbPddreEo35O6jT6i0RVK6LhsoYBhq5TvK4/n74wnA0QbK8gGd+jUZwTMKJw==",
-      "dev": true,
-      "dependencies": {
-        "config-chain": "^1.1.13",
-        "editorconfig": "^0.15.3",
-        "glob": "^8.0.3",
-        "nopt": "^6.0.0"
-      },
-      "bin": {
-        "css-beautify": "js/bin/css-beautify.js",
-        "html-beautify": "js/bin/html-beautify.js",
-        "js-beautify": "js/bin/js-beautify.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/js-beautify/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/js-beautify/node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/js-beautify/node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/js-beautify/node_modules/nopt": {
-      "version": "6.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/nopt/-/nopt-6.0.0.tgz",
-      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
-      "dev": true,
-      "dependencies": {
-        "abbrev": "^1.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11460,158 +11187,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/license-checker-rseidelsohn": {
-      "version": "3.1.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/license-checker-rseidelsohn/-/license-checker-rseidelsohn-3.1.0.tgz",
-      "integrity": "sha512-rcwDcRacbKlAKfdwuQNw4pa8L9bH3GWHFSg7k9b5kFhWugVD/VPfx92AkZOwRzGqTYAj2iN26bXNP30mmAUKSw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "debug": "^4.3.2",
-        "lodash.clonedeep": "^4.5.0",
-        "mkdirp": "^1.0.4",
-        "nopt": "^5.0.0",
-        "read-installed-packages": "^1.0.0",
-        "semver": "^7.3.5",
-        "spdx-correct": "^3.1.1",
-        "spdx-expression-parse": "^3.0.1",
-        "spdx-satisfies": "^5.0.1",
-        "treeify": "^1.1.0"
-      },
-      "bin": {
-        "license-checker-rseidelsohn": "bin/license-checker-rseidelsohn"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/license-checker-rseidelsohn/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/license-checker-rseidelsohn/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/license-checker-rseidelsohn/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/license-checker-rseidelsohn/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/license-checker-rseidelsohn/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/license-checker-rseidelsohn/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/license-checker-rseidelsohn/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/license-checker-rseidelsohn/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/license-checker-rseidelsohn/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/license-checker-rseidelsohn/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/license-checker-rseidelsohn/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/license-checker-rseidelsohn/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -11659,18 +11234,6 @@
       "version": "4.17.21",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
-      "dev": true
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "dev": true
     },
     "node_modules/lodash.escape": {
@@ -12711,69 +12274,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/normalize-package-data": {
-      "version": "3.0.3",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -12783,12 +12283,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-      "dev": true
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -13445,20 +12939,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/pretty": {
-      "version": "2.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/pretty/-/pretty-2.0.0.tgz",
-      "integrity": "sha512-G9xUchgTEiNpormdYBl+Pha50gOUovT18IvAe7EYMZ1/f9W/WWMPRn+xI68yXNMUk3QXHDwo/1wV/4NejVNe1w==",
-      "dev": true,
-      "dependencies": {
-        "condense-newlines": "^0.2.1",
-        "extend-shallow": "^2.0.1",
-        "js-beautify": "^1.6.12"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/process/-/process-0.11.10.tgz",
@@ -13517,12 +12997,6 @@
         "object.assign": "^4.1.0",
         "reflect.ownkeys": "^0.2.0"
       }
-    },
-    "node_modules/proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-      "dev": true
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -13771,58 +13245,6 @@
         "react": "^16.14.0"
       }
     },
-    "node_modules/read-installed-packages": {
-      "version": "1.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/read-installed-packages/-/read-installed-packages-1.0.0.tgz",
-      "integrity": "sha512-CZdFN0oYn7Iko+X8ynOztXNfbpO7UvAw1qEboRXCASP/psVrdt8LTvmwUYhAUF9q1dnD5R7lW4pmbpO6CQsfOg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.1",
-        "read-package-json": "^4.0.0",
-        "readdir-scoped-modules": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5 || 6 || 7",
-        "slide": "~1.1.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.2"
-      }
-    },
-    "node_modules/read-installed-packages/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/read-installed-packages/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/read-package-json": {
-      "version": "4.1.2",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/read-package-json/-/read-package-json-4.1.2.tgz",
-      "integrity": "sha512-Dqer4pqzamDE2O4M55xp1qZMuLPqi4ldk2ya648FOMHRjwMzFhuxVrG04wd0c38IsvkVdr3vgHI6z+QTPdAjrQ==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "normalize-package-data": "^3.0.0",
-        "npm-normalize-package-bin": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -13847,18 +13269,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/readdir-scoped-modules": {
-      "version": "1.1.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
-      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
-      "dev": true,
-      "dependencies": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
       }
     },
     "node_modules/readdirp": {
@@ -14310,12 +13720,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
-      "dev": true
-    },
     "node_modules/signal-exit": {
       "version": "3.0.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -14343,15 +13747,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/slide": {
-      "version": "1.1.6",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/snapdragon": {
       "version": "0.8.2",
@@ -14565,66 +13960,6 @@
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/spdx-compare": {
-      "version": "1.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-compare/-/spdx-compare-1.0.0.tgz",
-      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
-      "dev": true,
-      "dependencies": {
-        "array-find-index": "^1.0.2",
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-ranges": "^2.0.0"
-      }
-    },
-    "node_modules/spdx-correct": {
-      "version": "3.1.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-correct/-/spdx-correct-3.1.1.tgz",
-      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-      "dev": true,
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "dev": true
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.12",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
-      "dev": true
-    },
-    "node_modules/spdx-ranges": {
-      "version": "2.1.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
-      "integrity": "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==",
-      "dev": true
-    },
-    "node_modules/spdx-satisfies": {
-      "version": "5.0.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-satisfies/-/spdx-satisfies-5.0.1.tgz",
-      "integrity": "sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==",
-      "dev": true,
-      "dependencies": {
-        "spdx-compare": "^1.0.0",
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-ranges": "^2.0.0"
-      }
     },
     "node_modules/split-string": {
       "version": "3.1.0",
@@ -15331,15 +14666,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/treeify": {
-      "version": "1.1.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/treeify/-/treeify-1.1.0.tgz",
-      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/ts-jest": {
       "version": "27.1.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ts-jest/-/ts-jest-27.1.3.tgz",
@@ -15744,15 +15070,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/typical": {
-      "version": "4.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -15996,16 +15313,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/vary": {
@@ -17280,19 +16587,6 @@
     }
   },
   "dependencies": {
-    "@adsk/adsk-npm-license-puller": {
-      "version": "3.7.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/@adsk/adsk-npm-license-puller/-/@adsk/adsk-npm-license-puller-3.7.0.tgz",
-      "integrity": "sha512-YrNhVGRHa+Zmn47MXAWw2OIbE3ZWjiogiWmvYyVfLJakQUZLOTp/MFVjMb3Hl7+8Cwo8Qx0v5SxdhxBxSVjpSA==",
-      "dev": true,
-      "requires": {
-        "command-line-args": "^5.1.1",
-        "convert-array-to-csv": "^1.0.9",
-        "html-entities": "^1.2.1",
-        "license-checker-rseidelsohn": "^3.1.0",
-        "pretty": "^2.0.0"
-      }
-    },
     "@ampproject/remapping": {
       "version": "2.1.2",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/@ampproject/remapping/-/remapping-2.1.2.tgz",
@@ -20127,12 +19421,6 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/accepts/-/accepts-1.3.8.tgz",
@@ -20299,22 +19587,10 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
-    "array-back": {
-      "version": "3.1.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true
-    },
     "array-filter": {
       "version": "1.0.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/array-filter/-/array-filter-1.0.0.tgz",
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
-      "dev": true
-    },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
       "dev": true
     },
     "array-flatten": {
@@ -20348,12 +19624,6 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.0-next.1"
       }
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true
     },
     "asn1.js": {
       "version": "5.4.1",
@@ -21323,18 +20593,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
-      "dev": true,
-      "requires": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      }
-    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/commander/-/commander-2.20.3.tgz",
@@ -21371,38 +20629,6 @@
         "typedarray": "^0.0.6"
       }
     },
-    "condense-newlines": {
-      "version": "0.2.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/condense-newlines/-/condense-newlines-0.2.1.tgz",
-      "integrity": "sha512-P7X+QL9Hb9B/c8HI5BFFKmjgBu2XpQuF98WZ9XkO+dBGgk5XgwiQz7o1SmpglNWId3581UcS0SFAWfoIhMHPfg==",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-whitespace": "^0.3.0",
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "config-chain": {
-      "version": "1.1.13",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/config-chain/-/config-chain-1.1.13.tgz",
-      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-      "dev": true,
-      "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
-      }
-    },
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -21434,12 +20660,6 @@
       "version": "1.0.4",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
-    "convert-array-to-csv": {
-      "version": "1.0.12",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/convert-array-to-csv/-/convert-array-to-csv-1.0.12.tgz",
-      "integrity": "sha512-1PcSrmuJ+IhwTQ76ivWdMrQmM68gLbyaM44aXUIfbyPehvzPHdsv4iJh5yZtDN/G1zIhECsQMvzLpGxh2+pmkA==",
-      "dev": true
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -21682,12 +20902,6 @@
         "ms": "2.0.0"
       }
     },
-    "debuglog": {
-      "version": "1.0.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/debuglog/-/debuglog-1.0.1.tgz",
-      "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
-      "dev": true
-    },
     "decimal.js": {
       "version": "10.3.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/decimal.js/-/decimal.js-10.3.1.tgz",
@@ -21779,16 +20993,6 @@
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
-    "dezalgo": {
-      "version": "1.0.4",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/dezalgo/-/dezalgo-1.0.4.tgz",
-      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
-      "dev": true,
-      "requires": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
-    },
     "diff-sequences": {
       "version": "27.5.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/diff-sequences/-/diff-sequences-27.5.1.tgz",
@@ -21879,18 +21083,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
-      }
-    },
-    "editorconfig": {
-      "version": "0.15.3",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/editorconfig/-/editorconfig-0.15.3.tgz",
-      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.19.0",
-        "lru-cache": "^4.1.5",
-        "semver": "^5.6.0",
-        "sigmund": "^1.0.1"
       }
     },
     "ee-first": {
@@ -22592,15 +21784,6 @@
         }
       }
     },
-    "find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dev": true,
-      "requires": {
-        "array-back": "^3.0.1"
-      }
-    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/find-up/-/find-up-4.1.0.tgz",
@@ -22947,32 +22130,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
     "html-element-map": {
       "version": "1.2.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/html-element-map/-/html-element-map-1.2.0.tgz",
@@ -22981,12 +22138,6 @@
       "requires": {
         "array-filter": "^1.0.0"
       }
-    },
-    "html-entities": {
-      "version": "1.4.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/html-entities/-/html-entities-1.4.0.tgz",
-      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
-      "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -23163,12 +22314,6 @@
       "version": "2.0.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "ini": {
-      "version": "1.3.8",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "internal-slot": {
@@ -23446,12 +22591,6 @@
       "requires": {
         "call-bind": "^1.0.2"
       }
-    },
-    "is-whitespace": {
-      "version": "0.3.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/is-whitespace/-/is-whitespace-0.3.0.tgz",
-      "integrity": "sha512-RydPhl4S6JwAyj0JJjshWJEFG6hNye3pZFBRZaTUfZFwGHxzppNaNOVgQuS/E/SlhrApuMXrpnK1EEIXfdo3Dg==",
-      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -25423,60 +24562,6 @@
         }
       }
     },
-    "js-beautify": {
-      "version": "1.14.6",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/js-beautify/-/js-beautify-1.14.6.tgz",
-      "integrity": "sha512-GfofQY5zDp+cuHc+gsEXKPpNw2KbPddreEo35O6jT6i0RVK6LhsoYBhq5TvK4/n74wnA0QbK8gGd+jUZwTMKJw==",
-      "dev": true,
-      "requires": {
-        "config-chain": "^1.1.13",
-        "editorconfig": "^0.15.3",
-        "glob": "^8.0.3",
-        "nopt": "^6.0.0"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "8.0.3",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/glob/-/glob-8.0.3.tgz",
-          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^5.0.1",
-            "once": "^1.3.0"
-          }
-        },
-        "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        },
-        "nopt": {
-          "version": "6.0.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/nopt/-/nopt-6.0.0.tgz",
-          "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
-          "dev": true,
-          "requires": {
-            "abbrev": "^1.0.0"
-          }
-        }
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -25541,121 +24626,6 @@
         "type-check": "~0.3.2"
       }
     },
-    "license-checker-rseidelsohn": {
-      "version": "3.1.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/license-checker-rseidelsohn/-/license-checker-rseidelsohn-3.1.0.tgz",
-      "integrity": "sha512-rcwDcRacbKlAKfdwuQNw4pa8L9bH3GWHFSg7k9b5kFhWugVD/VPfx92AkZOwRzGqTYAj2iN26bXNP30mmAUKSw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.2",
-        "debug": "^4.3.2",
-        "lodash.clonedeep": "^4.5.0",
-        "mkdirp": "^1.0.4",
-        "nopt": "^5.0.0",
-        "read-installed-packages": "^1.0.0",
-        "semver": "^7.3.5",
-        "spdx-correct": "^3.1.1",
-        "spdx-expression-parse": "^3.0.1",
-        "spdx-satisfies": "^5.0.1",
-        "treeify": "^1.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -25693,18 +24663,6 @@
       "version": "4.17.21",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
-      "dev": true
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "dev": true
     },
     "lodash.escape": {
@@ -26486,63 +25444,10 @@
       "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
       "dev": true
     },
-    "nopt": {
-      "version": "5.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
-      }
-    },
-    "normalize-package-data": {
-      "version": "3.0.3",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
-    },
-    "npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
       "dev": true
     },
     "npm-run-path": {
@@ -27018,17 +25923,6 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "pretty": {
-      "version": "2.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/pretty/-/pretty-2.0.0.tgz",
-      "integrity": "sha512-G9xUchgTEiNpormdYBl+Pha50gOUovT18IvAe7EYMZ1/f9W/WWMPRn+xI68yXNMUk3QXHDwo/1wV/4NejVNe1w==",
-      "dev": true,
-      "requires": {
-        "condense-newlines": "^0.2.1",
-        "extend-shallow": "^2.0.1",
-        "js-beautify": "^1.6.12"
-      }
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/process/-/process-0.11.10.tgz",
@@ -27077,12 +25971,6 @@
         "object.assign": "^4.1.0",
         "reflect.ownkeys": "^0.2.0"
       }
-    },
-    "proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -27287,49 +26175,6 @@
         "scheduler": "^0.19.1"
       }
     },
-    "read-installed-packages": {
-      "version": "1.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/read-installed-packages/-/read-installed-packages-1.0.0.tgz",
-      "integrity": "sha512-CZdFN0oYn7Iko+X8ynOztXNfbpO7UvAw1qEboRXCASP/psVrdt8LTvmwUYhAUF9q1dnD5R7lW4pmbpO6CQsfOg==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.3.1",
-        "graceful-fs": "^4.1.2",
-        "read-package-json": "^4.0.0",
-        "readdir-scoped-modules": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5 || 6 || 7",
-        "slide": "~1.1.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
-      }
-    },
-    "read-package-json": {
-      "version": "4.1.2",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/read-package-json/-/read-package-json-4.1.2.tgz",
-      "integrity": "sha512-Dqer4pqzamDE2O4M55xp1qZMuLPqi4ldk2ya648FOMHRjwMzFhuxVrG04wd0c38IsvkVdr3vgHI6z+QTPdAjrQ==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "normalize-package-data": "^3.0.0",
-        "npm-normalize-package-bin": "^1.0.0"
-      }
-    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -27354,18 +26199,6 @@
             "safe-buffer": "~5.1.0"
           }
         }
-      }
-    },
-    "readdir-scoped-modules": {
-      "version": "1.1.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
-      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
-      "dev": true,
-      "requires": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
       }
     },
     "readdirp": {
@@ -27713,12 +26546,6 @@
         "object-inspect": "^1.9.0"
       }
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
-      "dev": true
-    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -27740,12 +26567,6 @@
       "version": "1.0.5",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
       "dev": true
     },
     "snapdragon": {
@@ -27917,66 +26738,6 @@
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "dev": true
-    },
-    "spdx-compare": {
-      "version": "1.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-compare/-/spdx-compare-1.0.0.tgz",
-      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
-      "dev": true,
-      "requires": {
-        "array-find-index": "^1.0.2",
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-ranges": "^2.0.0"
-      }
-    },
-    "spdx-correct": {
-      "version": "3.1.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-correct/-/spdx-correct-3.1.1.tgz",
-      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.12",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
-      "dev": true
-    },
-    "spdx-ranges": {
-      "version": "2.1.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
-      "integrity": "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==",
-      "dev": true
-    },
-    "spdx-satisfies": {
-      "version": "5.0.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-satisfies/-/spdx-satisfies-5.0.1.tgz",
-      "integrity": "sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==",
-      "dev": true,
-      "requires": {
-        "spdx-compare": "^1.0.0",
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-ranges": "^2.0.0"
-      }
     },
     "split-string": {
       "version": "3.1.0",
@@ -28484,12 +27245,6 @@
       "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
       "dev": true
     },
-    "treeify": {
-      "version": "1.1.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/treeify/-/treeify-1.1.0.tgz",
-      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
-      "dev": true
-    },
     "ts-jest": {
       "version": "27.1.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ts-jest/-/ts-jest-27.1.3.tgz",
@@ -28742,12 +27497,6 @@
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
-    "typical": {
-      "version": "4.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "dev": true
-    },
     "unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -28937,16 +27686,6 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         }
-      }
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "underscore": "^1.12.1"
       },
       "devDependencies": {
+        "@adsk/adsk-npm-license-puller": "^3.7.0",
         "@types/chai": "^3.4.35",
         "@types/enzyme": "^3.10.8",
         "@types/enzyme-adapter-react-16": "^1.0.6",
@@ -46,6 +47,22 @@
         "webpack": "^4.46.0",
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-cli": "^4.9.2"
+      }
+    },
+    "node_modules/@adsk/adsk-npm-license-puller": {
+      "version": "3.7.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/@adsk/adsk-npm-license-puller/-/@adsk/adsk-npm-license-puller-3.7.0.tgz",
+      "integrity": "sha512-YrNhVGRHa+Zmn47MXAWw2OIbE3ZWjiogiWmvYyVfLJakQUZLOTp/MFVjMb3Hl7+8Cwo8Qx0v5SxdhxBxSVjpSA==",
+      "dev": true,
+      "dependencies": {
+        "command-line-args": "^5.1.1",
+        "convert-array-to-csv": "^1.0.9",
+        "html-entities": "^1.2.1",
+        "license-checker-rseidelsohn": "^3.1.0",
+        "pretty": "^2.0.0"
+      },
+      "bin": {
+        "adsk-npm-license-puller": "bin/index.js"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3954,6 +3971,12 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/accepts/-/accepts-1.3.8.tgz",
@@ -4193,11 +4216,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/array-filter": {
       "version": "1.0.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/array-filter/-/array-filter-1.0.0.tgz",
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
       "dev": true
+    },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -4244,6 +4285,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
     },
     "node_modules/asn1.js": {
       "version": "5.4.1",
@@ -5521,6 +5568,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dev": true,
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/commander/-/commander-2.20.3.tgz",
@@ -5562,6 +5624,42 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/condense-newlines": {
+      "version": "0.2.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/condense-newlines/-/condense-newlines-0.2.1.tgz",
+      "integrity": "sha512-P7X+QL9Hb9B/c8HI5BFFKmjgBu2XpQuF98WZ9XkO+dBGgk5XgwiQz7o1SmpglNWId3581UcS0SFAWfoIhMHPfg==",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-whitespace": "^0.3.0",
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/condense-newlines/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
       }
     },
     "node_modules/console-browserify": {
@@ -5617,6 +5715,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-array-to-csv": {
+      "version": "1.0.12",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/convert-array-to-csv/-/convert-array-to-csv-1.0.12.tgz",
+      "integrity": "sha512-1PcSrmuJ+IhwTQ76ivWdMrQmM68gLbyaM44aXUIfbyPehvzPHdsv4iJh5yZtDN/G1zIhECsQMvzLpGxh2+pmkA==",
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "1.7.0",
@@ -5932,6 +6036,15 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.3.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/decimal.js/-/decimal.js-10.3.1.tgz",
@@ -6052,6 +6165,16 @@
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "license": "MIT"
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "27.5.1",
@@ -6176,6 +6299,21 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
       }
     },
     "node_modules/ee-first": {
@@ -7129,6 +7267,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/find-up/-/find-up-4.1.0.tgz",
@@ -7632,6 +7782,36 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/html-element-map": {
       "version": "1.2.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/html-element-map/-/html-element-map-1.2.0.tgz",
@@ -7643,6 +7823,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "1.4.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
+      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -7898,6 +8084,12 @@
       "version": "2.0.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "node_modules/internal-slot": {
@@ -8318,6 +8510,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-whitespace": {
+      "version": "0.3.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/is-whitespace/-/is-whitespace-0.3.0.tgz",
+      "integrity": "sha512-RydPhl4S6JwAyj0JJjshWJEFG6hNye3pZFBRZaTUfZFwGHxzppNaNOVgQuS/E/SlhrApuMXrpnK1EEIXfdo3Dg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-windows": {
@@ -11102,6 +11303,78 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-beautify": {
+      "version": "1.14.6",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/js-beautify/-/js-beautify-1.14.6.tgz",
+      "integrity": "sha512-GfofQY5zDp+cuHc+gsEXKPpNw2KbPddreEo35O6jT6i0RVK6LhsoYBhq5TvK4/n74wnA0QbK8gGd+jUZwTMKJw==",
+      "dev": true,
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^0.15.3",
+        "glob": "^8.0.3",
+        "nopt": "^6.0.0"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-beautify/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-beautify/node_modules/nopt": {
+      "version": "6.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11187,6 +11460,158 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/license-checker-rseidelsohn": {
+      "version": "3.1.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/license-checker-rseidelsohn/-/license-checker-rseidelsohn-3.1.0.tgz",
+      "integrity": "sha512-rcwDcRacbKlAKfdwuQNw4pa8L9bH3GWHFSg7k9b5kFhWugVD/VPfx92AkZOwRzGqTYAj2iN26bXNP30mmAUKSw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "debug": "^4.3.2",
+        "lodash.clonedeep": "^4.5.0",
+        "mkdirp": "^1.0.4",
+        "nopt": "^5.0.0",
+        "read-installed-packages": "^1.0.0",
+        "semver": "^7.3.5",
+        "spdx-correct": "^3.1.1",
+        "spdx-expression-parse": "^3.0.1",
+        "spdx-satisfies": "^5.0.1",
+        "treeify": "^1.1.0"
+      },
+      "bin": {
+        "license-checker-rseidelsohn": "bin/license-checker-rseidelsohn"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -11234,6 +11659,18 @@
       "version": "4.17.21",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
+      "dev": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "dev": true
     },
     "node_modules/lodash.escape": {
@@ -12274,6 +12711,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -12283,6 +12783,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+      "dev": true
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -12939,6 +13445,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty": {
+      "version": "2.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/pretty/-/pretty-2.0.0.tgz",
+      "integrity": "sha512-G9xUchgTEiNpormdYBl+Pha50gOUovT18IvAe7EYMZ1/f9W/WWMPRn+xI68yXNMUk3QXHDwo/1wV/4NejVNe1w==",
+      "dev": true,
+      "dependencies": {
+        "condense-newlines": "^0.2.1",
+        "extend-shallow": "^2.0.1",
+        "js-beautify": "^1.6.12"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/process/-/process-0.11.10.tgz",
@@ -12997,6 +13517,12 @@
         "object.assign": "^4.1.0",
         "reflect.ownkeys": "^0.2.0"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -13245,6 +13771,58 @@
         "react": "^16.14.0"
       }
     },
+    "node_modules/read-installed-packages": {
+      "version": "1.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/read-installed-packages/-/read-installed-packages-1.0.0.tgz",
+      "integrity": "sha512-CZdFN0oYn7Iko+X8ynOztXNfbpO7UvAw1qEboRXCASP/psVrdt8LTvmwUYhAUF9q1dnD5R7lW4pmbpO6CQsfOg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "read-package-json": "^4.0.0",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5 || 6 || 7",
+        "slide": "~1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/read-installed-packages/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/read-installed-packages/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/read-package-json": {
+      "version": "4.1.2",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/read-package-json/-/read-package-json-4.1.2.tgz",
+      "integrity": "sha512-Dqer4pqzamDE2O4M55xp1qZMuLPqi4ldk2ya648FOMHRjwMzFhuxVrG04wd0c38IsvkVdr3vgHI6z+QTPdAjrQ==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "normalize-package-data": "^3.0.0",
+        "npm-normalize-package-bin": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -13269,6 +13847,18 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/readdir-scoped-modules": {
+      "version": "1.1.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+      "dev": true,
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
       }
     },
     "node_modules/readdirp": {
@@ -13720,6 +14310,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "3.0.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -13747,6 +14343,15 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/snapdragon": {
       "version": "0.8.2",
@@ -13960,6 +14565,66 @@
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/spdx-compare": {
+      "version": "1.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-compare/-/spdx-compare-1.0.0.tgz",
+      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+      "dev": true,
+      "dependencies": {
+        "array-find-index": "^1.0.2",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.12",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+      "dev": true
+    },
+    "node_modules/spdx-ranges": {
+      "version": "2.1.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
+      "integrity": "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==",
+      "dev": true
+    },
+    "node_modules/spdx-satisfies": {
+      "version": "5.0.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-satisfies/-/spdx-satisfies-5.0.1.tgz",
+      "integrity": "sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==",
+      "dev": true,
+      "dependencies": {
+        "spdx-compare": "^1.0.0",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
     },
     "node_modules/split-string": {
       "version": "3.1.0",
@@ -14666,6 +15331,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/treeify": {
+      "version": "1.1.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "27.1.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ts-jest/-/ts-jest-27.1.3.tgz",
@@ -15070,6 +15744,15 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -15313,6 +15996,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/vary": {
@@ -16587,6 +17280,19 @@
     }
   },
   "dependencies": {
+    "@adsk/adsk-npm-license-puller": {
+      "version": "3.7.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/@adsk/adsk-npm-license-puller/-/@adsk/adsk-npm-license-puller-3.7.0.tgz",
+      "integrity": "sha512-YrNhVGRHa+Zmn47MXAWw2OIbE3ZWjiogiWmvYyVfLJakQUZLOTp/MFVjMb3Hl7+8Cwo8Qx0v5SxdhxBxSVjpSA==",
+      "dev": true,
+      "requires": {
+        "command-line-args": "^5.1.1",
+        "convert-array-to-csv": "^1.0.9",
+        "html-entities": "^1.2.1",
+        "license-checker-rseidelsohn": "^3.1.0",
+        "pretty": "^2.0.0"
+      }
+    },
     "@ampproject/remapping": {
       "version": "2.1.2",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/@ampproject/remapping/-/remapping-2.1.2.tgz",
@@ -19421,6 +20127,12 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/accepts/-/accepts-1.3.8.tgz",
@@ -19587,10 +20299,22 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true
+    },
     "array-filter": {
       "version": "1.0.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/array-filter/-/array-filter-1.0.0.tgz",
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
       "dev": true
     },
     "array-flatten": {
@@ -19624,6 +20348,12 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.0-next.1"
       }
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
     },
     "asn1.js": {
       "version": "5.4.1",
@@ -20593,6 +21323,18 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dev": true,
+      "requires": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/commander/-/commander-2.20.3.tgz",
@@ -20629,6 +21371,38 @@
         "typedarray": "^0.0.6"
       }
     },
+    "condense-newlines": {
+      "version": "0.2.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/condense-newlines/-/condense-newlines-0.2.1.tgz",
+      "integrity": "sha512-P7X+QL9Hb9B/c8HI5BFFKmjgBu2XpQuF98WZ9XkO+dBGgk5XgwiQz7o1SmpglNWId3581UcS0SFAWfoIhMHPfg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-whitespace": "^0.3.0",
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -20660,6 +21434,12 @@
       "version": "1.0.4",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "convert-array-to-csv": {
+      "version": "1.0.12",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/convert-array-to-csv/-/convert-array-to-csv-1.0.12.tgz",
+      "integrity": "sha512-1PcSrmuJ+IhwTQ76ivWdMrQmM68gLbyaM44aXUIfbyPehvzPHdsv4iJh5yZtDN/G1zIhECsQMvzLpGxh2+pmkA==",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -20902,6 +21682,12 @@
         "ms": "2.0.0"
       }
     },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+      "dev": true
+    },
     "decimal.js": {
       "version": "10.3.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/decimal.js/-/decimal.js-10.3.1.tgz",
@@ -20993,6 +21779,16 @@
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "diff-sequences": {
       "version": "27.5.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/diff-sequences/-/diff-sequences-27.5.1.tgz",
@@ -21083,6 +21879,18 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
       }
     },
     "ee-first": {
@@ -21784,6 +22592,15 @@
         }
       }
     },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
+      "requires": {
+        "array-back": "^3.0.1"
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/find-up/-/find-up-4.1.0.tgz",
@@ -22130,6 +22947,32 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "html-element-map": {
       "version": "1.2.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/html-element-map/-/html-element-map-1.2.0.tgz",
@@ -22138,6 +22981,12 @@
       "requires": {
         "array-filter": "^1.0.0"
       }
+    },
+    "html-entities": {
+      "version": "1.4.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
+      "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -22314,6 +23163,12 @@
       "version": "2.0.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "internal-slot": {
@@ -22591,6 +23446,12 @@
       "requires": {
         "call-bind": "^1.0.2"
       }
+    },
+    "is-whitespace": {
+      "version": "0.3.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/is-whitespace/-/is-whitespace-0.3.0.tgz",
+      "integrity": "sha512-RydPhl4S6JwAyj0JJjshWJEFG6hNye3pZFBRZaTUfZFwGHxzppNaNOVgQuS/E/SlhrApuMXrpnK1EEIXfdo3Dg==",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -24562,6 +25423,60 @@
         }
       }
     },
+    "js-beautify": {
+      "version": "1.14.6",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/js-beautify/-/js-beautify-1.14.6.tgz",
+      "integrity": "sha512-GfofQY5zDp+cuHc+gsEXKPpNw2KbPddreEo35O6jT6i0RVK6LhsoYBhq5TvK4/n74wnA0QbK8gGd+jUZwTMKJw==",
+      "dev": true,
+      "requires": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^0.15.3",
+        "glob": "^8.0.3",
+        "nopt": "^6.0.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "nopt": {
+          "version": "6.0.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/nopt/-/nopt-6.0.0.tgz",
+          "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+          "dev": true,
+          "requires": {
+            "abbrev": "^1.0.0"
+          }
+        }
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -24626,6 +25541,121 @@
         "type-check": "~0.3.2"
       }
     },
+    "license-checker-rseidelsohn": {
+      "version": "3.1.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/license-checker-rseidelsohn/-/license-checker-rseidelsohn-3.1.0.tgz",
+      "integrity": "sha512-rcwDcRacbKlAKfdwuQNw4pa8L9bH3GWHFSg7k9b5kFhWugVD/VPfx92AkZOwRzGqTYAj2iN26bXNP30mmAUKSw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.2",
+        "debug": "^4.3.2",
+        "lodash.clonedeep": "^4.5.0",
+        "mkdirp": "^1.0.4",
+        "nopt": "^5.0.0",
+        "read-installed-packages": "^1.0.0",
+        "semver": "^7.3.5",
+        "spdx-correct": "^3.1.1",
+        "spdx-expression-parse": "^3.0.1",
+        "spdx-satisfies": "^5.0.1",
+        "treeify": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -24663,6 +25693,18 @@
       "version": "4.17.21",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "dev": true
     },
     "lodash.escape": {
@@ -25444,10 +26486,63 @@
       "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
       "dev": true
     },
+    "nopt": {
+      "version": "5.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
       "dev": true
     },
     "npm-run-path": {
@@ -25923,6 +27018,17 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "pretty": {
+      "version": "2.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/pretty/-/pretty-2.0.0.tgz",
+      "integrity": "sha512-G9xUchgTEiNpormdYBl+Pha50gOUovT18IvAe7EYMZ1/f9W/WWMPRn+xI68yXNMUk3QXHDwo/1wV/4NejVNe1w==",
+      "dev": true,
+      "requires": {
+        "condense-newlines": "^0.2.1",
+        "extend-shallow": "^2.0.1",
+        "js-beautify": "^1.6.12"
+      }
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/process/-/process-0.11.10.tgz",
@@ -25971,6 +27077,12 @@
         "object.assign": "^4.1.0",
         "reflect.ownkeys": "^0.2.0"
       }
+    },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -26175,6 +27287,49 @@
         "scheduler": "^0.19.1"
       }
     },
+    "read-installed-packages": {
+      "version": "1.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/read-installed-packages/-/read-installed-packages-1.0.0.tgz",
+      "integrity": "sha512-CZdFN0oYn7Iko+X8ynOztXNfbpO7UvAw1qEboRXCASP/psVrdt8LTvmwUYhAUF9q1dnD5R7lW4pmbpO6CQsfOg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.1",
+        "graceful-fs": "^4.1.2",
+        "read-package-json": "^4.0.0",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5 || 6 || 7",
+        "slide": "~1.1.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "read-package-json": {
+      "version": "4.1.2",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/read-package-json/-/read-package-json-4.1.2.tgz",
+      "integrity": "sha512-Dqer4pqzamDE2O4M55xp1qZMuLPqi4ldk2ya648FOMHRjwMzFhuxVrG04wd0c38IsvkVdr3vgHI6z+QTPdAjrQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "normalize-package-data": "^3.0.0",
+        "npm-normalize-package-bin": "^1.0.0"
+      }
+    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -26199,6 +27354,18 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "readdir-scoped-modules": {
+      "version": "1.1.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
       }
     },
     "readdirp": {
@@ -26546,6 +27713,12 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -26567,6 +27740,12 @@
       "version": "1.0.5",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
       "dev": true
     },
     "snapdragon": {
@@ -26738,6 +27917,66 @@
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "dev": true
+    },
+    "spdx-compare": {
+      "version": "1.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-compare/-/spdx-compare-1.0.0.tgz",
+      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.2",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.12",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+      "dev": true
+    },
+    "spdx-ranges": {
+      "version": "2.1.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
+      "integrity": "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==",
+      "dev": true
+    },
+    "spdx-satisfies": {
+      "version": "5.0.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/spdx-satisfies/-/spdx-satisfies-5.0.1.tgz",
+      "integrity": "sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==",
+      "dev": true,
+      "requires": {
+        "spdx-compare": "^1.0.0",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
     },
     "split-string": {
       "version": "3.1.0",
@@ -27245,6 +28484,12 @@
       "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
       "dev": true
     },
+    "treeify": {
+      "version": "1.1.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true
+    },
     "ts-jest": {
       "version": "27.1.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ts-jest/-/ts-jest-27.1.3.tgz",
@@ -27497,6 +28742,12 @@
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "dev": true
+    },
     "unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -27686,6 +28937,16 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         }
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vary": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "cross-env NODE_ENV=development webpack",
     "prod": "cross-env NODE_ENV=production webpack",
     "serve": "npm run dev & node ./index.js",
-    "lic_direct": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_direct.html --about-box-type desktop --year 2022 --paos ./license_output/paos_direct.csv --throw",
+    "lic_direct": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_direct.html --about-box-type desktop --year 2022 --paos ./license_output/paos_direct.csv",
     "lic_transitive": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_transitive.html --about-box-type desktop --transitive  --year 2022 --paos ./license_output/paos_transitive.csv",
     "generate_license":"npm run lic_direct && npm run lic_transitive"
   },

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "dev": "cross-env NODE_ENV=development webpack",
     "prod": "cross-env NODE_ENV=production webpack",
     "serve": "npm run dev & node ./index.js",
-    "lic_direct": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_direct.html --about-box-type desktop --year 2022 --paos ./license_output/paos_direct.csv",
-    "lic_transitive": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_transitive.html --about-box-type desktop --transitive  --year 2022 --paos ./license_output/paos_transitive.csv",
-    "generate_license": "npm install @adsk/adsk-npm-license-puller --no-save --force && npm run lic_direct && npm run lic_transitive"
+    "lic_direct": "npx @adsk/adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_direct.html --about-box-type desktop --year 2022 --paos ./license_output/paos_direct.csv",
+    "lic_transitive": "npx @adsk/adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_transitive.html --about-box-type desktop --transitive --year 2022 --paos ./license_output/paos_transitive.csv",
+    "generate_license": "npm run lic_direct && npm run lic_transitive"
   },
   "keywords": [
     "Dynamo",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "dev": "cross-env NODE_ENV=development webpack",
     "prod": "cross-env NODE_ENV=production webpack",
     "serve": "npm run dev & node ./index.js",
-    "lic_direct": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_direct.html --about-box-type desktop",
-    "lic_transitive": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_transitive.html --about-box-type desktop --transitive",
+    "lic_direct": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_direct.html --about-box-type desktop --year 2022 --paos ./license_output/paos_direct.csv --throw",
+    "lic_transitive": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_transitive.html --about-box-type desktop --transitive  --year 2022 --paos ./license_output/paos_transitive.csv",
     "generate_license":"npm run lic_direct && npm run lic_transitive"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "serve": "npm run dev & node ./index.js",
     "lic_direct": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_direct.html --about-box-type desktop --year 2022 --paos ./license_output/paos_direct.csv",
     "lic_transitive": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_transitive.html --about-box-type desktop --transitive  --year 2022 --paos ./license_output/paos_transitive.csv",
-    "generate_license":"npm run lic_direct && npm run lic_transitive"
+    "generate_license": "npm install @adsk/adsk-npm-license-puller --no-save --force && npm run lic_direct && npm run lic_transitive"
   },
   "keywords": [
     "Dynamo",
@@ -28,7 +28,6 @@
     "underscore": "^1.12.1"
   },
   "devDependencies": {
-    "@adsk/adsk-npm-license-puller": "^3.7.0",
     "@types/chai": "^3.4.35",
     "@types/enzyme": "^3.10.8",
     "@types/enzyme-adapter-react-16": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "build": "npm run prod",
     "dev": "cross-env NODE_ENV=development webpack",
     "prod": "cross-env NODE_ENV=production webpack",
-    "serve": "npm run dev & node ./index.js"
+    "serve": "npm run dev & node ./index.js",
+    "lic_direct": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_direct.html --about-box-type desktop",
+    "lic_transitive": "npx adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_transitive.html --about-box-type desktop --transitive",
+    "generate_license":"npm run lic_direct && npm run lic_transitive"
   },
   "keywords": [
     "Dynamo",
@@ -25,6 +28,7 @@
     "underscore": "^1.12.1"
   },
   "devDependencies": {
+    "@adsk/adsk-npm-license-puller": "^3.7.0",
     "@types/chai": "^3.4.35",
     "@types/enzyme": "^3.10.8",
     "@types/enzyme-adapter-react-16": "^1.0.6",


### PR DESCRIPTION
This PR does the following:
* adds a dev dependency on `adsk-npm-license-puller` of the latest version (thanks @twastvedt for your work here)
* this tool will only exist when using adsk npm registry!
* adds a npm script `generate_license` which will create two different about box .html files.

Next:
- [x] send a similar PR to notification center
- [ ] in Dynamo - consume the about box html with a webBrowser control (or similar) in the about box.