### PR TITLE
DYN-5813-fix-failing-librariejs-builds

### DIFF
--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -28,7 +28,7 @@ export interface LibraryItemProps {
     showItemSummary: boolean,
     isLastItem?: boolean,
     onItemWillExpand?: Function,
-    tooltipContent: any
+    tooltipContent?: any
 }
 
 export interface LibraryItemState {


### PR DESCRIPTION
Purpose
This PR implements [DYN-5813](https://jira.autodesk.com/browse/DYN-5813) (Fix failing librariejs builds)

This PR modify the LibraryItemProps interface making the tooltipContent prop optional

Reviewers @QilongTang @RobertGlobant20 