### PR TITLE
hotfix: remove onTextChanged execution within forward delete

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -84,7 +84,6 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     }
 
     UNSAFE_componentWillMount() {
-        // window.handleKeyDown = this.handleKeyDown();
         window.addEventListener("keydown", this.handleKeyDown.bind(this));
         window.addEventListener("click", this.handleGlobalClick.bind(this));
     }
@@ -140,7 +139,6 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
         this.searchInputField.value = searchValueCopy.join("");
         this.searchInputField.focus();
         this.searchInputField.setSelectionRange(cursor, cursor);
-        this.props.onTextChanged(this.searchInputField.value);
     }
 
     onTextChanged(event: any) {


### PR DESCRIPTION
This PR removes onTextChanged execution within the forward delete implementation related to [DYN-6064](https://jira.autodesk.com/browse/DYN-6064). This onTextChanged is causing some unexpected behaviour while expanding nodes 

**FYI** 
@RobertGlobant20 
@QilongTang 