### PR TITLE
add(searchBar): events binding and methods for copy and paste

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -3,8 +3,6 @@ import * as ReactDOM from 'react-dom';
 import * as _ from 'underscore';
 import { ObjectExtensions } from '../LibraryUtilities'
 
-type StructuredModeChangedFunc = (structured: boolean) => void;
-
 type DetailedModeChangedFunc = (detailed: boolean) => void;
 
 type SearchCategoriesChangedFunc = (categories: string[], categoryData: CategoryData[]) => void;
@@ -15,7 +13,6 @@ type SearchBarExpandedFunc = (event: any) => void;
 
 export interface SearchBarProps {
     onTextChanged: SearchTextChangedFunc;
-    onStructuredModeChanged: StructuredModeChangedFunc;
     onDetailedModeChanged: DetailedModeChangedFunc;
     onCategoriesChanged: SearchCategoriesChangedFunc;
     categories: string[];

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -3,6 +3,8 @@ import * as ReactDOM from 'react-dom';
 import * as _ from 'underscore';
 import { ObjectExtensions } from '../LibraryUtilities'
 
+type StructuredModeChangedFunc = (structured: boolean) => void;
+
 type DetailedModeChangedFunc = (detailed: boolean) => void;
 
 type SearchCategoriesChangedFunc = (categories: string[], categoryData: CategoryData[]) => void;
@@ -13,6 +15,7 @@ type SearchBarExpandedFunc = (event: any) => void;
 
 export interface SearchBarProps {
     onTextChanged: SearchTextChangedFunc;
+    onStructuredModeChanged: StructuredModeChangedFunc;
     onDetailedModeChanged: DetailedModeChangedFunc;
     onCategoriesChanged: SearchCategoriesChangedFunc;
     categories: string[];

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -195,14 +195,12 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     }
 
     onExpandButtonClick() {
-        let expanded = !this.state.expanded;
-        this.setState({ expanded });
+        this.setState(prevState => ({expanded: !prevState.expanded}));
     }
 
     onDetailedModeChanged(event: any) {
-        let value = !this.state.detailed;
-        this.props.onDetailedModeChanged(value);
-        this.setState({ detailed: value });
+        this.setState(prevState => ({detailed: !prevState.detailed}));
+        this.props.onDetailedModeChanged(this.state.detailed);
     }
 
     getSelectedCategories(): string[]{

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -160,21 +160,28 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
         //@ts-ignore
         let text = await chrome.webview.hostObjects.scriptObject.PasteFromClipboard();
         //@ts-ignore
+        
+        const field = this.searchInputField;
+        const searchValueCopy = field.value.split("");
+        let cursor = field.selectionStart ?? 0;
+        let selectionLength = 0;
 
-        let cursor = this.searchInputField.selectionStart ?? 0;
-        const searchValueCopy = this.searchInputField.value.split("");
-        searchValueCopy.splice(cursor, 0, text);
-        this.searchInputField.value = searchValueCopy.join("");
-        this.searchInputField.focus();
+        if(document.getSelection()) {
+            selectionLength = document.getSelection()?.toString().length ?? 0;
+        }
+        
+        searchValueCopy.splice(cursor, selectionLength, text);
+        field.value = searchValueCopy.join("");
+        field.focus();
 
-        this.searchInputField.setSelectionRange(cursor + text.length, cursor + text.length);
+        field.setSelectionRange(cursor + text.length, cursor + text.length);
 
-        let hasText = this.searchInputField.value.length > 0;
+        let hasText = field.value.length > 0;
         let expanded = !hasText ? false : this.state.expanded;
 
         if (this.state.hasText || hasText) {
             this.setState({ expanded: expanded, hasText: hasText });
-            this.props.onTextChanged(this.searchInputField.value);
+            this.props.onTextChanged(field.value);
         }
     }
 


### PR DESCRIPTION
This PR implements events binding for ctrl+C and ctrl+V keydown events and respective methods to handle dynamo clipboard as webview2 doesn't allow us to manage navigator clipboard.

**FYI**
@QilongTang 
@RobertGlobant20 