### PR TITLE
DYN-5745 feat(SearchBar): add full text selection for search bar input

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -34,6 +34,7 @@ enum EventKey {
     ARROW_DOWN = "ArrowDown",
     DELETE = "Delete",
     ESCAPE =  "Escape",
+    KEYA = "A",
     KEYC = "C",
     KEYV = "V"
 };
@@ -94,6 +95,9 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
             case EventKey.DELETE:
                 this.forwardDelete(event);
                 break;
+            case EventKey.KEYA:
+                this.fullTextSelection();
+            break;
             case EventKey.KEYC:
                 this.copyToClipboard();
                 break;
@@ -142,6 +146,13 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
             this.setState({ expanded: expanded, hasText: hasText });
             this.props.onTextChanged(this.searchInputField.value);
         }
+    }
+
+    fullTextSelection() {
+        if (!this.searchInputField) return;
+
+        this.searchInputField.focus();
+        this.searchInputField.setSelectionRange(0, this.searchInputField.value.length);
     }
 
     async copyToClipboard() {


### PR DESCRIPTION

![Screen Recording 2023-10-24 at 14 17 33](https://github.com/DynamoDS/librarie.js/assets/111511512/cd89df94-d8e3-4ede-b7cf-282e35cc1a6a)

This PR enables the full text selection for library search input using ctrl + A.

**Review**
@QilongTang 