### PR TITLE
DYN-6270 Bugfix webpack.config regex rule for asset resource

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,7 @@ module.exports = {
                 use: ["style-loader", "css-loader"]
             },
             {
-                test: /\^(?:.ttf|.otf|.eot|.woff|.svg|.png)$/,
+                test: /\.(?:ttf|otf|eot|woff|svg|png)$/,
                 type: 'asset/resource',
                 generator:{
                     filename:'resources/[name][ext][query]'


### PR DESCRIPTION
Fix the regex rule applied to asset resources that made library build fail.

**REVIEW**
@avidit 