### PR TITLE
fix(searchBar): delete in library search

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -134,7 +134,8 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
         if (!this.searchInputField) return;
         let cursor = this.searchInputField.selectionStart ?? 0;
         const searchValueCopy = this.searchInputField.value.split("");
-        searchValueCopy.splice(cursor, 1);
+        const selectionLength = window.getSelection()?.toString().length === 0 ? 1 : window.getSelection()?.toString().length;
+        searchValueCopy.splice(cursor, selectionLength);
         this.searchInputField.value = searchValueCopy.join("");
         this.searchInputField.focus();
         this.searchInputField.setSelectionRange(cursor, cursor);


### PR DESCRIPTION
This is a bugfix related to ref.: [DYN-6426](https://jira.autodesk.com/browse/DYN-6426)
Now we're deleting based on the length of the text selection.

![Screen Recording 2023-11-13 at 15 56 06](https://github.com/DynamoDS/librarie.js/assets/111511512/356b8bee-d8f2-43bf-8a01-270cf4874472)


**REVIEW**
@QilongTang 

**FYI**
@reddyashish 