### PR TITLE
[DYN-6740] fix(librarySearch): typing-in-an-upper-V-the-clipboard-is-pasted-there

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -85,6 +85,20 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     }
 
     handleKeyDown(event: any) {
+        if(event.ctrlKey === true) {
+            switch (event.key) {
+                case EventKey.KEYA:
+                this.fullTextSelection();
+                break;
+                case (EventKey.KEYC):
+                    this.copyToClipboard();
+                    break;
+                case (EventKey.KEYV):
+                    this.pasteFromClipboard();
+                break;
+            }
+        }
+
         switch (event.key) {
             case EventKey.ARROW_DOWN:
                 event.preventDefault();
@@ -95,15 +109,6 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
             case EventKey.DELETE:
                 this.forwardDelete(event);
                 break;
-            case EventKey.KEYA:
-                this.fullTextSelection();
-            break;
-            case EventKey.KEYC:
-                this.copyToClipboard();
-                break;
-            case EventKey.KEYV:
-                this.pasteFromClipboard();
-            break;
             default:
                 if (event.target.className == "SearchInputText") {
                     this.searchInputField?.focus();


### PR DESCRIPTION
This PR corrects unexpected behaviors related to LibrarySearch. The modifier Key for `Ctrl+C` , ` Ctrl+V`... was not being tracked.
Ref.: [DYN-6740](https://jira.autodesk.com/browse/DYN-6740)

**Review**
@QilongTang 

**FYI**
@avidit 