### PR TITLE
[DYN-6796] feat: adjust font sizes and paddings giving higher density

### DIFF
--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -110,7 +110,7 @@ button {
 	display: flex;
 	padding: 0rem 1.5rem;
 	margin-top: 1.5rem;
-	font-size: 1.4rem;
+	font-size: 1.2rem;
 	color: #f5f5f5f5;
 	align-items: center;
 	justify-content: space-between;
@@ -137,7 +137,7 @@ button {
 }
 
 .LibraryItemContainerCategory > .LibraryItemHeader {
-	padding: .85rem 1.5rem;
+	padding: .7rem 1.5rem;
 	width: calc(100% - 3rem);
 }
 
@@ -210,14 +210,16 @@ button {
 	padding: 2px 8px 2px 4px;
 }
 
+.LibraryItemText {
+	font-size: 1rem;
+}
+
 .LibraryItemContainerCategory .LibraryItemText {
 	color: #ade4de;
-	font-size: 1.2rem;
 }
 
 .LibraryItemContainerNone .LibraryItemText {
 	color: #eeeeee;
-	font-size: 1.2rem;
 }
 
 .LibraryItemHeader .LibraryItemGroupText,
@@ -228,12 +230,12 @@ button {
 
 .LibraryItemHeader .LibraryItemGroupText {
 	color: #eeeeee;
-	font-size: 1.2rem;
+	font-size: 1rem;
 }
 
 .LibraryItemParameters {
 	color: #888;
-	font-size: 1rem;
+	font-size: .9rem;
 	margin-left: 5px;
 	display: inline-block;
 }
@@ -379,7 +381,6 @@ button {
 }
 
 .ClusterRightPane .LibraryItemText{
-	font-size: 1.1rem;
 	width: 100%;
 	color: #C6C6C6;
 }
@@ -454,7 +455,7 @@ button {
 	padding-top: 1.2rem;
 	padding-bottom: 1.2rem;
 	color: #f5f5f5f5;
-	font-size: 1.4rem;
+	font-size: 1.2rem;
 }
 
 .SearchBar .Icon {
@@ -474,7 +475,7 @@ button {
 	border: none;
 	width: 100%;
 	color: #999999;
-	font-size: 1rem;
+	font-size: .9rem;
 }
 
 .SearchInput .SearchInputText::-webkit-input-placeholder {
@@ -794,7 +795,7 @@ button {
 
 .SearchResultItemContainer .ItemInfo,
 .SearchResultItemContainerSelected .ItemInfo {
-	padding: 5px 0px 5px 0px;
+	padding: 2px 0px 2px 0px;
 }
 
 .SearchResultItemContainer .ItemIcon,
@@ -809,7 +810,7 @@ button {
 .SearchResultItemContainer .ItemTitle,
 .SearchResultItemContainerSelected .ItemTitle {
 	margin-bottom: 2px;
-	font-size: 1.2rem;
+	font-size: 1rem;
 }
 
 .SearchResultItemContainer .ItemDescription,
@@ -823,7 +824,7 @@ button {
 .SearchResultItemContainerSelected .ItemDetails {
 	display: flex;
 	align-items: center;
-	font-size: 1rem;
+	font-size: .9rem;
 	color: #aaaaaa;
 }
 


### PR DESCRIPTION
This PR fix the density differences after implemented new icons.

**Before**

<img width="375" alt="library" src="https://github.com/DynamoDS/librarie.js/assets/111511512/d9a64ad3-ce81-456a-bf70-6d1a8776b971">

<img width="375" alt="library_search_results" src="https://github.com/DynamoDS/librarie.js/assets/111511512/0f60931e-d929-4455-8dc0-f9b30a584b81">


**After**
<img width="375" alt="library" src="https://github.com/DynamoDS/librarie.js/assets/111511512/7398a4ec-070d-473d-a7f6-0c48d29fe78c">

<img width="375" alt="library_search_results" src="https://github.com/DynamoDS/librarie.js/assets/111511512/f12e3470-c7f4-4f23-ab4f-05b672fb8bf8">

**Review**
@QilongTang 