### PR TITLE
[DYN-2316] implement GitHub actions to publish librarie js npm package for every release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: PR Build
+
+on:
+  push:
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: npm ci --force
+      - run: npm run build --if-present
+      - run: npm test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,47 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Publish release
+
+on:
+  # uncomment the following if you need to debug manual trigger
+  # workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  # Build dev first
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci --force
+      - run: npm run build:dev --if-present
+      - run: npm test
+
+  # Build prod bundle and publish publicly
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci --force
+      - run: npm run production --if-present
+      - run: npm test
+        env:
+          # Set environment to production just in case
+          NODE_ENV: production
+      - name: The final publish step within dist folder
+        working-directory: dist
+        # This will publish the package and set access to public as if you had run npm access public after publishing.
+        run: npm publish --access public
+        env:
+          # Get npm token from Github
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -43,16 +43,6 @@ ci_test:
     format: "junit"
     pattern: "*.xml"
 
-deployment:
-  -
-    type: customized
-    customized_builder_image:
-      registry: artifactory
-      url: artifactory.dev.adskengineer.net/dynamo/dynamolibrariejs:dotnetcore3_node16_v2
-    scripts:
-      - "dotnet pack -c Release -o nuget --version-suffix \"beta$BUILD_NUMBER\""
-      - "dotnet nuget push \"$(find nuget -type f -name *.nupkg)\" -s https://api.nuget.org/v3/index.json -k $API_KEY"
-      
 soc2:
   run_on_any_branch : true
   harmony:


### PR DESCRIPTION
This PR includes Github Actions build and npm-publish for package management uses and remove deployment step in pipeline to ditch Nuget package management.

**Review: **
@QilongTang 