### PR TITLE
feat: add 1px top/bottom to gain some space between nodes in tree view display

### DIFF
--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -361,6 +361,10 @@ button {
     padding-left: 0rem;
 }
 
+.ClusterRightPane .LibraryItemContainerNone .LibraryItemHeader {
+	padding: 1px 0px;
+}
+
 .ClusterRightPane .LibraryItemTextWrapper {
 	width: 100%;
 	display: flex;


### PR DESCRIPTION
This PR increases the space between nodes in tree view display

<img width="277" alt="one-pixel-top-bottom" src="https://github.com/DynamoDS/librarie.js/assets/111511512/3444ecdf-8079-42dd-bef6-a36d17837704">

**Review**
@QilongTang 