### PR TITLE
[DYN-6769] fix: rename npm production script to match github action statement

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "cross-env NODE_ENV=production --mode=development webpack",
     "bundle": "cross-env NODE_ENV=production --mode=production webpack",
     "copy": "cp package.json dist/ && cp README.md dist/ && cp -r license_output dist/",
-    "prod": "npm run bundle && npm run copy",
+    "production": "npm run bundle && npm run copy",
     "serve": "npm run dev & node ./index.js",
     "lic_direct": "npx @adsk/adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_direct.html --about-box-type desktop --year 2022 --paos ./license_output/paos_direct.csv",
     "lic_transitive": "npx @adsk/adsk-npm-license-puller --path . --app-name 'librarieJS' --verbose --about-box ./license_output/about-box_transitive.html --about-box-type desktop --transitive --year 2022 --paos ./license_output/paos_transitive.csv",


### PR DESCRIPTION
Rename npm production script `npm prod` matching github action statement which calls `npm production` so the dist folder will be created as expected.

**Review**
@QilongTang 