### PR TITLE
[DYN-6796] improve library node icons look

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <div id="libraryContainerPlaceholder"></div>
 
     <!-- The main library view compoment -->
-    <script src='./dist/librarie.js'></script>
+    <script src='./dist/build/librarie.js'></script>
     <!-- uncomment to debug in IE11 (polyfill fetch and promise)
     <script src="//cdn.jsdelivr.net/npm/bluebird@3.7.2/js/browser/bluebird.min.js"></script>
     <script src='https://unpkg.com/whatwg-fetch@3.6.2/dist/fetch.umd.js'></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynamods/librariejs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynamods/librariejs",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.36.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/librariejs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Project that contains all hosted contents of Dynamo Windows client",
   "main": "index.js",
   "scripts": {

--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -159,11 +159,15 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
         this.props.data.itemType !== "coregroup" &&
         this.props.data.itemType !== "classType" &&
         this.props.data.itemType !== "none") {
-            return <img
-                className={"LibraryItemIcon"}
-                src={this.props.data.iconUrl}
-                onError={this.onImageLoadFail}
-            />;
+            return (
+                <div className="LibraryItemIconWrapper">
+                    <img
+                        className={"LibraryItemIcon"}
+                        src={this.props.data.iconUrl}
+                        onError={this.onImageLoadFail}
+                    />
+                </div>
+            );
         }
 
          // If it is a section, display the icon (if given) and provide a click interaction.

--- a/src/resources/LibraryStyles.css
+++ b/src/resources/LibraryStyles.css
@@ -197,12 +197,19 @@ button {
 	-webkit-user-drag: none;
 }
 
-.LibraryItemContainerNone .LibraryItemIcon {
-	align-self: flex-start;
-	padding-left: 0.5rem;
-	padding-right: 0.5rem;
+.LibraryItemContainerNone .LibraryItemIconWrapper {
 	width: 2.5rem;
 	height: 2.5rem;
+	margin: 0rem 0.3rem;
+}
+
+.LibraryItemContainerNone .LibraryItemIcon {
+	align-self: flex-start;
+	height: 100%;
+	width: 100%;
+	object-fit: scale-down;
+	padding: 0rem;
+	padding-right: 0.5rem;
 	-webkit-user-drag: none;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = {
     output: {
         filename: productionBuild ? "librarie.min.js" : "librarie.js",
         path: path.join(__dirname, '/dist/build'),
-        publicPath: "./dist/build",
+        publicPath: "./dist/build/",
         libraryTarget: "umd",
         library: "LibraryEntryPoint",
     },


### PR DESCRIPTION
This PR includes a fix commit for load resources properly as we have changed publicPath recently.
Also improves nodes icons look adding more room between nodes.

**Result**
<img width="279" alt="06MvP4Yz8d" src="https://github.com/DynamoDS/librarie.js/assets/111511512/201b6e5c-84b6-44b7-adf9-98bf384dcf93">

**Review:**
@QilongTang 

