### PR TITLE
Revert "remove(LibraryItem):forced scroll at componentDidMount"

### DIFF
--- a/src/components/LibraryItem.tsx
+++ b/src/components/LibraryItem.tsx
@@ -100,6 +100,26 @@ export class LibraryItem extends React.Component<LibraryItemProps, LibraryItemSt
             }
     }
 
+    //Afer rendering each Library item, scroll to the expanded item
+    componentDidMount() {
+        if (this.props.data.expanded && this.props.data.itemType !== "coregroup") {
+            //scroll to only that element clicked from search. Determining that element from 
+            //other elements is little tricky. The idea here is, the element which has
+            //its child elements expanded to false is the actual element clicked from search. Scroll
+            //to that element.
+            let isThereChildItemsToExpand = this.props.data.childItems.filter((item: any) => {
+                return item.expanded == true;
+            });
+            if (isThereChildItemsToExpand.length == 0) {
+                setTimeout(() => {
+                    let elem = ReactDOM.findDOMNode(this);
+                    elem.scrollIntoView(false);
+                }, 0);
+            }
+
+        }
+    }
+
     render() {
         if ((this.props.libraryContainer.state?.hostingContext == HostingContextType.home)
             && this.props.data.hiddenInWorkspaceContext){


### PR DESCRIPTION
Reverting https://github.com/DynamoDS/librarie.js/pull/188. 

This should fix the bug related to scrolling to the item in the library component. 

Task: https://jira.autodesk.com/browse/DYN-6491

![library scroll](https://github.com/DynamoDS/librarie.js/assets/43763136/90babfad-aa7f-4d6d-8788-cd4b391654b3)



@Enzo707 @QilongTang 